### PR TITLE
fix(frontend): unstick parallel subagents during arrival/departure

### DIFF
--- a/frontend/src/hooks/useWebSocketEvents.ts
+++ b/frontend/src/hooks/useWebSocketEvents.ts
@@ -196,10 +196,15 @@ export function useWebSocketEvents({
       for (const agentId of currentAgentIds) {
         if (!backendAgentIds.has(agentId)) {
           const agent = store.agents.get(agentId);
+          if (!agent) continue;
 
-          // Only trigger departure if agent is idle at desk
-          if (agent && agent.phase === "idle") {
+          if (agent.phase === "idle") {
             agentMachineService.triggerDeparture(agentId);
+          } else {
+            // Backend removed the agent before its arrival animation reached
+            // the desk. Queue the departure so it fires once the agent is
+            // idle, instead of waiting for the next state-update.
+            agentMachineService.markPendingDeparture(agentId);
           }
         }
       }

--- a/frontend/src/machines/agentMachine.ts
+++ b/frontend/src/machines/agentMachine.ts
@@ -167,6 +167,12 @@ export const createAgentMachine = (actions: AgentMachineActions) =>
                 on: {
                   BUBBLE_DISPLAYED: "agent_responds",
                 },
+                // Safety net: if BUBBLE_DISPLAYED is never sent (e.g. boss
+                // bubble was suppressed during session completion), advance
+                // anyway so the agent does not freeze in front of the boss.
+                after: {
+                  CONVERSATION_TIMEOUT: "agent_responds",
+                },
               },
               agent_responds: {
                 entry: ["incrementConversationStep", "showArrivalAgentBubble"],
@@ -287,11 +293,20 @@ export const createAgentMachine = (actions: AgentMachineActions) =>
                 on: {
                   BUBBLE_DISPLAYED: "boss_responds",
                 },
+                after: {
+                  CONVERSATION_TIMEOUT: "boss_responds",
+                },
               },
               boss_responds: {
                 entry: ["incrementConversationStep", "showDepartureBossBubble"],
                 on: {
                   BUBBLE_DISPLAYED: "done",
+                },
+                // Safety net: if BUBBLE_DISPLAYED never fires (boss bubble
+                // suppressed during completion / session winding down) the
+                // agent would otherwise freeze in front of the boss desk.
+                after: {
+                  CONVERSATION_TIMEOUT: "done",
                 },
               },
               done: {

--- a/frontend/src/machines/agentMachineCommon.ts
+++ b/frontend/src/machines/agentMachineCommon.ts
@@ -403,6 +403,11 @@ export const sharedDelays = {
   BOSS_PAUSE: 100,
   ELEVATOR_PAUSE: 500,
   DOOR_CLOSE_DELAY: 520, // Wait for door close animation (500ms) + minimal buffer
+  // Maximum time to wait inside a conversing sub-state before forcibly
+  // advancing. The bubble normally lives 3000ms; this is a safety net for
+  // the case where the bubble is suppressed (boss completing / persistent)
+  // and the BUBBLE_DISPLAYED event is never delivered.
+  CONVERSATION_TIMEOUT: 5000,
 } as const;
 
 // ============================================================================

--- a/frontend/src/machines/agentMachineService.ts
+++ b/frontend/src/machines/agentMachineService.ts
@@ -52,6 +52,15 @@ class AgentMachineService {
   // Reference count for elevator usage — only close when all agents are done
   private elevatorUsageCount = 0;
 
+  /**
+   * Agents that the backend has removed but whose frontend animation hasn't
+   * reached "idle" yet. When such an agent finally arrives at its desk, we
+   * fire its departure flow immediately instead of waiting for the next
+   * backend state-update (which may never come if the session is winding
+   * down).
+   */
+  private pendingDepartures: Set<string> = new Set();
+
   constructor() {
     // Initialize actions that bridge state machine to store
     this.actions = {
@@ -149,7 +158,19 @@ class AgentMachineService {
       );
       return;
     }
+    this.pendingDepartures.delete(agentId);
     managed.actor.send({ type: "REMOVE" });
+  }
+
+  /**
+   * Mark an agent as needing to depart once it reaches the idle state.
+   * Used when the backend removes an agent before its arrival animation
+   * has finished — the actual REMOVE event is dispatched in
+   * handlePhaseChanged when phase becomes "idle".
+   */
+  markPendingDeparture(agentId: string): void {
+    if (!this.agents.has(agentId)) return;
+    this.pendingDepartures.add(agentId);
   }
 
   /**
@@ -251,6 +272,7 @@ class AgentMachineService {
     this.agents.clear();
     this.queue.reset();
     this.elevatorUsageCount = 0;
+    this.pendingDepartures.clear();
   }
 
   // ==========================================================================
@@ -394,20 +416,19 @@ class AgentMachineService {
   /**
    * Release the ready position for this agent and notify the next agent in
    * queue that it may now advance (via a microtask to avoid re-entrancy).
+   *
+   * Looks up by agentId rather than queueType because the store's queueType
+   * is cleared in handleQueueLeft (during in_queue → walking_to_ready), so
+   * by the time this runs (entering walking_to_desk / walking_to_elevator)
+   * the agent's stored queueType is already null.
    */
   private releaseReadyAndNotify(
     agentId: string,
-    store: ReturnType<typeof useGameStore.getState>,
+    _store: ReturnType<typeof useGameStore.getState>,
   ): void {
-    const agent = store.agents.get(agentId);
-    if (agent?.queueType) {
-      const released = this.queue.releaseReadyPosition(
-        agentId,
-        agent.queueType,
-      );
-      if (released) {
-        setTimeout(() => this.notifyBossAvailable(), 0);
-      }
+    const released = this.queue.releaseReadyPositionForAgent(agentId);
+    if (released) {
+      setTimeout(() => this.notifyBossAvailable(), 0);
     }
   }
 
@@ -493,6 +514,12 @@ class AgentMachineService {
     if (phase === "in_elevator") {
       store.updateAgentPosition(agentId, ELEVATOR_DEPARTURE_POSITION);
     }
+
+    // If the backend already removed this agent while it was still arriving,
+    // fire its departure now that it has reached its desk.
+    if (phase === "idle" && this.pendingDepartures.has(agentId)) {
+      setTimeout(() => this.triggerDeparture(agentId), 0);
+    }
   }
 
   private handleShowBossBubble(text: string, icon?: string): void {
@@ -505,6 +532,15 @@ class AgentMachineService {
       console.log(
         `[AgentMachineService] Skipping boss bubble "${text.slice(0, 30)}..." - isCompleting=${isCompleting}, hasPersistentBubble=${hasPersistentBubble}`,
       );
+      // Unblock any agent waiting for BUBBLE_DISPLAYED in the conversing
+      // sub-state. Without this, the agent gets stuck at A0 forever (and
+      // every other agent behind it in the queue stays standing too).
+      for (const [agentId, agent] of store.agents) {
+        if (agent.phase === "conversing") {
+          setTimeout(() => this.notifyBubbleComplete(agentId), 0);
+          break;
+        }
+      }
       return;
     }
 
@@ -571,6 +607,7 @@ class AgentMachineService {
     }
 
     this.queue.clearAllReservations(agentId);
+    this.pendingDepartures.delete(agentId);
 
     const queueType = this.queue.releaseReadyPositionForAgent(agentId);
     if (queueType) {


### PR DESCRIPTION
## Summary

When the orchestrator launches several subagents in parallel, the office visualizer was leaving most of them standing still — either in the arrival queue, in front of the boss desk, or at their own desk after finishing. This PR fixes three distinct bugs in the frontend agent state machine that all surfaced under parallel load.

## Bugs fixed

### 1. Ready-position never released → only the first agent reaches its desk
`AgentMachineService.releaseReadyAndNotify` looked up `agent.queueType` from the store to decide which ready slot (A0/D0) to free. But `handleQueueLeft` already clears that field when the agent transitions `in_queue → walking_to_ready`. By the time `releaseReadyAndNotify` ran (entering `walking_to_desk` / `walking_to_elevator`), `queueType` was `null`, the slot stayed marked as occupied forever, and `notifyBossAvailable` returned early for every subsequent agent.

**Fix:** look the agent up by `agentId` via the existing `releaseReadyPositionForAgent` helper, which doesn't depend on store state.

### 2. `SUBAGENT_STOP` arriving mid-arrival → agent stuck at its desk
If a fast subagent finished before its on-screen arrival animation completed, the backend removed it from the agent list, but `useWebSocketEvents` skipped `triggerDeparture` because `agent.phase !== "idle"`. No future state-update re-evaluated this, so the agent stayed at its desk until the next unrelated user prompt happened to push fresh state down the WebSocket.

**Fix:** when the backend removes an agent that isn't yet idle, mark it via a new `markPendingDeparture(agentId)` on the service. `handlePhaseChanged` then dispatches `triggerDeparture` as soon as that agent reaches `idle`.

### 3. Conversing sub-states wait forever when bubbles are suppressed
The `boss_speaks` (arrival) and `boss_responds` (departure) sub-states only leave on `BUBBLE_DISPLAYED`. `handleShowBossBubble` already drops the bubble when `boss.backendState === "completing"` or a persistent bubble is up, so under heavy parallelism the event was never delivered and an agent could freeze in front of the boss desk.

**Fix:** add a `CONVERSATION_TIMEOUT` (5s) `after` transition on both sub-states so conversation always advances, even when the bubble notification is dropped.

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm test` (Vitest) — all 21 tests pass
- [x] Launched 4 parallel subagents repeatedly via the main Claude orchestrator:
  - All four reach their desks
  - All four leave correctly after `SUBAGENT_STOP`
  - No agents left standing in front of the boss desk after session completion

## Files touched

- `frontend/src/machines/agentMachineService.ts` — bugs 1 & 2
- `frontend/src/hooks/useWebSocketEvents.ts` — bug 2 wiring
- `frontend/src/machines/agentMachine.ts` — bug 3
- `frontend/src/machines/agentMachineCommon.ts` — `CONVERSATION_TIMEOUT` delay