### PR TITLE
fix(backend): emit synthetic SubagentStop for zombie subagents

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -31,6 +31,14 @@ class Settings(BaseSettings):
     CLAUDE_PATH_HOST: str = ""
     CLAUDE_PATH_CONTAINER: str = ""
 
+    # When a subagent's transcript stays inactive for more than this many
+    # seconds, the transcript poller assumes the agent crashed (rate-limit,
+    # interruption, ...) and emits a synthetic SubagentStop so the office
+    # visualizer can clean it up. A regular agent makes a tool-call every
+    # few seconds, so 90s is comfortably above the noise floor while still
+    # catching zombies quickly.
+    ZOMBIE_SUBAGENT_TIMEOUT_SECONDS: int = 90
+
     model_config = SettingsConfigDict(env_file=".env")
 
     def translate_path(self, path: str) -> str:

--- a/backend/app/core/transcript_poller.py
+++ b/backend/app/core/transcript_poller.py
@@ -16,7 +16,15 @@ from app.models.events import Event, EventData, EventType
 logger = logging.getLogger(__name__)
 
 POLL_INTERVAL_SECONDS = 1.0
+
+# Hard upper bound — even if no zombie detection ever fires, give up after
+# this long. Kept high so legitimate long-running subagents are not killed.
 INACTIVITY_TIMEOUT = timedelta(minutes=10)
+
+
+def _zombie_timeout() -> timedelta:
+    """Return the configured zombie-subagent timeout as a timedelta."""
+    return timedelta(seconds=get_settings().ZOMBIE_SUBAGENT_TIMEOUT_SECONDS)
 
 
 @dataclass
@@ -104,8 +112,31 @@ class TranscriptPoller:
                     if not agent:
                         return
 
-                    # Check for inactivity timeout
-                    if datetime.now(UTC) - agent.last_activity > INACTIVITY_TIMEOUT:
+                    inactivity = datetime.now(UTC) - agent.last_activity
+                    zombie_timeout = _zombie_timeout()
+
+                    # Zombie detection: emit a synthetic SubagentStop so the
+                    # state machine can clean up the orphaned agent. This
+                    # covers cases where Claude Code never sends SubagentStop
+                    # itself (rate-limit, crash, user interrupt, ...).
+                    if inactivity > zombie_timeout:
+                        zombie_event = self._build_zombie_stop_event(agent)
+                        session_id = agent.session_id
+                        logger.warning(
+                            f"Agent {agent_id} appears to be a zombie "
+                            f"(no transcript activity for "
+                            f"{inactivity.total_seconds():.0f}s, "
+                            f"threshold {zombie_timeout.total_seconds():.0f}s) "
+                            f"— emitting synthetic SubagentStop on session {session_id}"
+                        )
+                        # Release the lock before invoking the callback to
+                        # avoid holding it across an arbitrarily long await.
+                        break
+
+                    # Hard fallback: if the zombie callback also failed for
+                    # any reason, eventually stop the loop so we do not poll
+                    # forever.
+                    if inactivity > INACTIVITY_TIMEOUT:
                         logger.debug(f"Agent {agent_id} timed out due to inactivity")
                         return
 
@@ -123,12 +154,32 @@ class TranscriptPoller:
                         await self._event_callback(event)
                     except Exception as e:
                         logger.warning(f"Error processing polled event: {e}")
+                continue
+
+            # Reached only when zombie_event was built above.
+            try:
+                await self._event_callback(zombie_event)
+            except Exception as e:
+                logger.warning(f"Error dispatching synthetic SubagentStop: {e}")
+            return
 
         except asyncio.CancelledError:
             logger.debug(f"Poll loop for agent {agent_id} cancelled")
             raise
         except Exception as e:
             logger.exception(f"Error in poll loop for agent {agent_id}: {e}")
+
+    def _build_zombie_stop_event(self, agent: "PolledAgent") -> Event:
+        """Build a synthetic SUBAGENT_STOP for an agent we believe has crashed."""
+        return Event(
+            event_type=EventType.SUBAGENT_STOP,
+            session_id=agent.session_id,
+            timestamp=datetime.now(UTC),
+            data=EventData(
+                agent_id=agent.agent_id,
+                agent_transcript_path=str(agent.transcript_path),
+            ),
+        )
 
     async def _read_new_content(self, agent: PolledAgent) -> list[Event]:
         """Read new content from the transcript file and extract events."""

--- a/backend/tests/test_transcript_poller.py
+++ b/backend/tests/test_transcript_poller.py
@@ -190,6 +190,45 @@ class TestTranscriptPoller:
             Path(temp_path).unlink(missing_ok=True)
 
     @pytest.mark.asyncio
+    async def test_emits_synthetic_subagent_stop_for_zombie(self) -> None:
+        """When a transcript stays inactive past the zombie threshold,
+        the poller should emit a synthetic SUBAGENT_STOP event."""
+        from datetime import timedelta
+
+        callback = AsyncMock()
+        poller = TranscriptPoller(callback)
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".jsonl", delete=False) as f:
+            temp_path = f.name
+
+        try:
+            # Force the zombie timeout to fire on the very first tick.
+            with (
+                patch("app.core.transcript_poller.POLL_INTERVAL_SECONDS", TEST_POLL_INTERVAL),
+                patch(
+                    "app.core.transcript_poller._zombie_timeout",
+                    return_value=timedelta(seconds=0),
+                ),
+            ):
+                await poller.start_polling("agent_zombie", "session1", temp_path)
+                # Give the poll loop time to detect the zombie and dispatch
+                await asyncio.sleep(0.3)
+                await poller.stop_polling("agent_zombie")
+
+            # Callback must have received exactly one synthetic SUBAGENT_STOP
+            stop_calls = [
+                call
+                for call in callback.call_args_list
+                if call[0][0].event_type == EventType.SUBAGENT_STOP
+            ]
+            assert len(stop_calls) == 1
+            event = stop_calls[0][0][0]
+            assert event.data.agent_id == "agent_zombie"
+            assert event.session_id == "session1"
+        finally:
+            Path(temp_path).unlink(missing_ok=True)
+
+    @pytest.mark.asyncio
     async def test_stop_all(self) -> None:
         """Should stop all polling tasks."""
         callback = AsyncMock()


### PR DESCRIPTION
## Summary

When a subagent dies without Claude Code delivering a SubagentStop hook (rate-limit, exception, user interrupt, ...), the backend never knows the agent is gone, so the office visualizer leaves the agent sitting at its desk forever. Today the only way to unstick it is to send another prompt — that triggers an unrelated state-update which incidentally re-renders the canvas.

This PR makes the existing transcript poller responsible for noticing those zombies and synthesising the missing SubagentStop event.

## What changed

- `backend/app/core/transcript_poller.py`: when a tracked transcript stays inactive for longer than `ZOMBIE_SUBAGENT_TIMEOUT_SECONDS`, build a synthetic `SUBAGENT_STOP` event and dispatch it through the existing event callback before stopping the polling task. The regular agent-removal pipeline (state machine → broadcast → frontend departure) takes it from there.
- `backend/app/config.py`: new setting `ZOMBIE_SUBAGENT_TIMEOUT_SECONDS` (default 90). Configurable via env so users with very long-running subagents can bump it up.
- The existing 10-minute `INACTIVITY_TIMEOUT` is kept as a defensive hard fallback in case the synthetic event itself ever fails to dispatch.

## Why 90 seconds?

A normal subagent makes a tool-call every few seconds, and each tool-call extends the transcript. 90s is comfortably above the noise floor of a long LLM call but small enough that a crashed agent leaves the office quickly.

## Test plan

- [x] Added `test_emits_synthetic_subagent_stop_for_zombie` — mocks the zombie timeout to 0s and asserts the synthetic SUBAGENT_STOP is dispatched with the expected `agent_id`/`session_id`.
- [x] All existing `test_transcript_poller.py` tests still pass (6/6)
- [x] `ruff check` clean
- [x] `pyright` clean on touched files

## Notes for reviewer

This complements (but is independent of) #29 which fixes three frontend animation bugs that surface under parallel subagent load.