### PR TITLE
fix: suppress hydration mismatch from browser extensions

### DIFF
--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -27,6 +27,7 @@ export default function RootLayout({
     <html lang="en">
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
+        suppressHydrationWarning
       >
         {children}
       </body>


### PR DESCRIPTION
## Summary
- Adds `suppressHydrationWarning` to `<body>` in `frontend/src/app/layout.tsx`
- Prevents React hydration errors caused by browser extensions injecting attributes (e.g. `data-atm-ext-installed`) into the DOM before hydration

## Test plan
- [ ] Verify no hydration mismatch error in browser console with a browser extension installed that modifies `<body>` attributes
- [ ] Confirm the app renders and functions normally without extensions

🤖 Generated with [Claude Code](https://claude.com/claude-code)