### PR TITLE
Fix: attribute subagents by explicit agent_type, not task description

### DIFF
--- a/backend/app/core/event_processor.py
+++ b/backend/app/core/event_processor.py
@@ -937,8 +937,14 @@ class EventProcessor:
             case EventType.SUBAGENT_START:
                 return f"Spawned subagent: {data.agent_name or data.agent_id}"
             case EventType.SUBAGENT_STOP:
-                status = "successfully" if data.success else "with errors"
-                return f"Subagent {data.agent_id} finished {status}"
+                # Native SubagentStop hook only sets native_agent_id; fall back to it,
+                # and default success=True when neither agent_id nor explicit failure marker
+                # is present (native hook fires on success).
+                aid = data.agent_id or (
+                    f"subagent_{data.native_agent_id}" if data.native_agent_id else "unknown"
+                )
+                status = "successfully" if (data.success or data.success is None) else "with errors"
+                return f"Subagent {aid} finished {status}"
             case EventType.STOP:
                 return "Main agent task complete"
             case EventType.CLEANUP:

--- a/backend/app/core/handlers/agent_handler.py
+++ b/backend/app/core/handlers/agent_handler.py
@@ -278,7 +278,9 @@ async def enrich_agent_with_summaries(
     task_source = event_data.task_description or event_data.agent_name or ""
 
     if name_source:
-        agent.name = await summary_service.generate_agent_name(name_source, existing_names)
+        agent.name = await summary_service.generate_agent_name(
+            name_source, existing_names, agent_type=event_data.agent_type
+        )
 
         # Final dedup guard in case of race
         if existing_names and agent.name in existing_names:

--- a/backend/app/core/state_machine.py
+++ b/backend/app/core/state_machine.py
@@ -871,7 +871,9 @@ class StateMachine:
         name_source = data.agent_name or data.task_description or ""
         summary_service = get_summary_service()
         existing_names = {a.name for a in self.agents.values() if a.name}
-        short_name = summary_service.generate_agent_name_fallback(name_source, existing_names)
+        short_name = summary_service.generate_agent_name_fallback(
+            name_source, existing_names, agent_type=data.agent_type
+        )
 
         task = data.task_description or data.agent_name or None
 

--- a/backend/app/core/summary_service.py
+++ b/backend/app/core/summary_service.py
@@ -14,6 +14,30 @@ logger = logging.getLogger(__name__)
 class SummaryService:
     """Service for generating AI-powered summaries using Claude Haiku."""
 
+    # Subagent_type slugs that have a curated name mapping in
+    # generate_agent_name_fallback. When the Agent tool reports one of these as
+    # the explicit subagent_type, we keep the mapped name and skip the AI namer
+    # (otherwise the AI rewrites e.g. an "explore" agent into "Data Diva").
+    # Keep in sync with the keys of `agent_type_names` below.
+    _MAPPED_AGENT_TYPES: frozenset[str] = frozenset({
+        "general-purpose",
+        "explore",
+        "plan",
+        "audit-architecture",
+        "audit-code-quality",
+        "audit-security",
+        "audit-documentation",
+        "fix-architecture",
+        "fix-code-quality",
+        "fix-security",
+        "fix-documentation",
+        "markdown-docs-writer",
+        "webgl-shader-expert",
+    })
+
+    def _known_agent_types(self) -> frozenset[str]:
+        return self._MAPPED_AGENT_TYPES
+
     def __init__(self) -> None:
         """Initialize the summary service with OAuth token if available."""
         settings = get_settings()
@@ -94,10 +118,18 @@ class SummaryService:
         return fallback
 
     async def generate_agent_name(
-        self, description: str, existing_names: set[str] | None = None
+        self,
+        description: str,
+        existing_names: set[str] | None = None,
+        agent_type: str | None = None,
     ) -> str:
         """Generate a fun, creative nickname for an agent based on its task."""
-        fallback = self.generate_agent_name_fallback(description, existing_names)
+        fallback = self.generate_agent_name_fallback(description, existing_names, agent_type)
+
+        # If the name came from an explicit, curated agent_type mapping, keep it
+        # rather than asking the AI to "improve" it.
+        if agent_type and agent_type.strip().lower() in self._known_agent_types():
+            return fallback
 
         if not self.enabled or not self.client:
             return fallback
@@ -138,16 +170,21 @@ class SummaryService:
         return fallback
 
     def generate_agent_name_fallback(
-        self, description: str, existing_names: set[str] | None = None
+        self,
+        description: str,
+        existing_names: set[str] | None = None,
+        agent_type: str | None = None,
     ) -> str:
-        """Generate a fun, creative agent name based on task type."""
+        """Generate a fun, creative agent name based on agent_type or task type."""
         import random
 
-        if not description or not description.strip():
+        taken = existing_names or set()
+
+        if (not description or not description.strip()) and not (agent_type and agent_type.strip()):
             return self.dedupe_name("The Intern", existing_names)
 
-        desc_lower = description.strip().lower()
-        taken = existing_names or set()
+        desc_lower = (description or "").strip().lower()
+        type_lower = (agent_type or "").strip().lower()
 
         # Handle agent_type values (subagent_type from Agent tool)
         agent_type_names: dict[str, list[str]] = {
@@ -165,9 +202,18 @@ class SummaryService:
             "markdown-docs-writer": ["The Scribe", "Doc Brown", "Word Wizard"],
             "webgl-shader-expert": ["Pixel Pete", "Shader Sam", "GPU Guru"],
         }
-        # Check for exact agent_type match
-        for agent_type, names in agent_type_names.items():
-            if desc_lower == agent_type or desc_lower.startswith(agent_type):
+        # Priority 1: exact match on the explicit subagent_type from the Agent tool.
+        # This is the reliable signal — task descriptions rarely start with the slug.
+        if type_lower and type_lower in agent_type_names:
+            names = agent_type_names[type_lower]
+            available = [n for n in names if n not in taken]
+            if available:
+                return random.choice(available)
+            return self.dedupe_name(random.choice(names), taken)
+
+        # Priority 2: legacy heuristic — description literally starts with a slug.
+        for at_key, names in agent_type_names.items():
+            if desc_lower == at_key or desc_lower.startswith(at_key):
                 available = [n for n in names if n not in taken]
                 if available:
                     return random.choice(available)


### PR DESCRIPTION
## Problem

Subagents spawned via the `Agent`/`Task` tool are always rendered with a **generic name** (e.g. "Algo Al") instead of the name curated for their `subagent_type` in `agent_type_names`. The `agentLifespans` / news feed show the wrong persona, and `SUBAGENT_STOP` entries in the event log read **"Subagent None finished with errors"**.

## Root cause

`generate_agent_name_fallback()` only received the task **description** and matched the `agent_type_names` map via `description.startswith(slug)`. But the description is the task prompt (e.g. *"Spawned subagent: run the tests"*), which almost never starts with a type slug — so the curated mapping never fired and every subagent fell through to a random/AI name.

The explicit `subagent_type` was already present on `EventData.agent_type` (and logged in `handle_subagent_start`), it just wasn't threaded into name generation.

## Changes

- `generate_agent_name_fallback()` / `generate_agent_name()` take an explicit `agent_type` param. The type is matched against the curated map **first**; the old `description.startswith` heuristic is kept as a fallback.
- `create_agent()` and `enrich_agent_with_summaries()` now pass through `EventData.agent_type`.
- New `_MAPPED_AGENT_TYPES` set: when a name is resolved from a curated `agent_type`, the AI namer is skipped so it isn't rewritten into something unrelated.
- `SUBAGENT_STOP` event summary falls back to `native_agent_id` and defaults `success=True` when the native SubagentStop hook omits `agent_id`/`success` (fixes the "Subagent None finished with errors" log line).

## Testing

- `pytest -k "subagent or agent_name or simulation or agent"` — all green.
- `ruff check` — clean on all touched files.
- Manually verified locally: two subagents of distinct `subagent_type` now render with their mapped names and distinct colors, and the stop log reads "finished successfully".

No behavior change for sessions that don't pass `subagent_type` — the description-based heuristic and AI namer still apply.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Bug Fixes**
- Enhanced reliability of subagent completion messages: now gracefully handles missing agent identifiers with improved fallback mechanisms to ensure complete event logging.
- Improved agent naming logic: agent names are now generated with consideration for agent type classification, providing more accurate and consistent identification across all agent creation flows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/paulrobello/claude-office/pull/36?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->