### PR TITLE
fix(security): harden localhost API, transcript paths, and uninstall

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to Claude Office Visualizer are documented here.
 
+## [Unreleased]
+
+### Security
+
+- **API URL validation**: Hook config now validates `CLAUDE_OFFICE_API_URL` is localhost-only, rejecting external URLs that could exfiltrate event data (#37)
+- **Transcript path validation**: Backend now validates all transcript file reads are under `~/.claude/` with `.jsonl` extension, preventing arbitrary file reads via crafted events (#37)
+- **API key authentication**: Backend accepts an optional `CLAUDE_OFFICE_API_KEY` — when set, all hook and WebSocket requests must include it. Key is auto-generated at install time (#37)
+- **WebSocket origin hardening**: Non-browser WebSocket connections (no `Origin` header) now require a valid API key when configured, closing the previous bypass (#37)
+
+### Fixed
+
+- **Incomplete uninstall**: `uninstall.sh` now removes the installed tool binary, config file, and debug log (#37)
+
+### Changed
+
+- **Dead code removal**: Removed unused `summarize_tool_call()` and `_get_tool_fallback()` from `SummaryService` (#37)
+
 ## [0.16.0] - 2026-05-20
 
 ### Fixed

--- a/backend/app/api/websocket.py
+++ b/backend/app/api/websocket.py
@@ -25,15 +25,23 @@ _ALLOWED_WS_ORIGINS = frozenset(
 def validate_websocket_origin(websocket: WebSocket) -> bool:
     """Check the Origin header on a WebSocket handshake.
 
-    Returns True if the origin is allowed (localhost) or absent (non-browser
-    clients like the test suite may not send Origin).  Returns False for
-    disallowed origins.
+    Browser connections must come from an allowed localhost origin.
+    Non-browser connections (no Origin header) must present a valid
+    X-API-Key header when CLAUDE_OFFICE_API_KEY is configured.
+    Returns False for disallowed origins or missing auth.
     """
     origin = websocket.headers.get("origin")
-    if origin is None:
-        # Non-browser clients (curl, test suite) -- rely on localhost middleware
+    if origin is not None:
+        return origin.rstrip("/") in _ALLOWED_WS_ORIGINS
+
+    # Non-browser clients (no Origin) — require API key when configured
+    from app.config import get_settings
+
+    key = get_settings().CLAUDE_OFFICE_API_KEY
+    if not key:
         return True
-    return origin.rstrip("/") in _ALLOWED_WS_ORIGINS
+    provided = websocket.headers.get("x-api-key", "")
+    return provided == key
 
 
 def validate_session_id(session_id: str) -> bool:

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -39,6 +39,11 @@ class Settings(BaseSettings):
     # catching zombies quickly.
     ZOMBIE_SUBAGENT_TIMEOUT_SECONDS: int = 90
 
+    # API key for authenticating hook requests. When set, all requests
+    # must include this value in the X-API-Key header. When empty, auth
+    # is skipped (backwards-compatible).
+    CLAUDE_OFFICE_API_KEY: str = ""
+
     model_config = SettingsConfigDict(env_file=".env")
 
     def translate_path(self, path: str) -> str:

--- a/backend/app/core/handlers/conversation_handler.py
+++ b/backend/app/core/handlers/conversation_handler.py
@@ -11,6 +11,7 @@ import logging
 
 from app.core.broadcast_service import broadcast_state
 from app.core.jsonl_parser import get_last_assistant_response
+from app.core.path_utils import is_safe_transcript_path
 from app.core.state_machine import StateMachine
 from app.core.summary_service import get_summary_service
 from app.models.common import BubbleContent, BubbleType
@@ -130,6 +131,10 @@ async def extract_and_set_boss_speech(
 
     settings = get_settings()
     translated_path = settings.translate_path(transcript_path)
+
+    if not is_safe_transcript_path(translated_path):
+        logger.warning(f"Rejected transcript path outside ~/.claude/: {translated_path}")
+        return None
 
     response = get_last_assistant_response(translated_path)
     if not response:

--- a/backend/app/core/jsonl_parser.py
+++ b/backend/app/core/jsonl_parser.py
@@ -5,6 +5,8 @@ import logging
 from pathlib import Path
 from typing import TypedDict
 
+from app.core.path_utils import is_safe_transcript_path
+
 logger = logging.getLogger(__name__)
 
 
@@ -41,6 +43,9 @@ def get_last_assistant_response(jsonl_path: str | Path) -> str | None:
         The last assistant text response, or None if not found or file doesn't exist.
     """
     path = Path(jsonl_path)
+    if not is_safe_transcript_path(path):
+        logger.warning(f"Rejected transcript path outside ~/.claude/: {jsonl_path}")
+        return None
     if not path.exists():
         logger.debug(f"Transcript file not found: {jsonl_path}")
         return None
@@ -96,6 +101,9 @@ def get_first_user_prompt(jsonl_path: str | Path) -> str | None:
         The first user text prompt, or None if not found or file doesn't exist.
     """
     path = Path(jsonl_path)
+    if not is_safe_transcript_path(path):
+        logger.warning(f"Rejected transcript path outside ~/.claude/: {jsonl_path}")
+        return None
     if not path.exists():
         logger.debug(f"Transcript file not found: {jsonl_path}")
         return None
@@ -148,6 +156,9 @@ def get_session_messages(
         List of message dicts with 'role' and 'text' keys.
     """
     path = Path(jsonl_path)
+    if not is_safe_transcript_path(path):
+        logger.warning(f"Rejected transcript path outside ~/.claude/: {jsonl_path}")
+        return []
     if not path.exists():
         logger.debug(f"Transcript file not found: {jsonl_path}")
         return []

--- a/backend/app/core/path_utils.py
+++ b/backend/app/core/path_utils.py
@@ -1,9 +1,22 @@
-"""Path compression utilities for UI display."""
+"""Path compression and validation utilities."""
 
+import logging
 from pathlib import Path
+
+logger = logging.getLogger(__name__)
 
 DEFAULT_PATH_MAX_LEN = 35
 DEFAULT_WORD_MAX_LEN = 30
+
+
+def is_safe_transcript_path(path: str | Path) -> bool:
+    """Return True if *path* is under ~/.claude/ and has a .jsonl extension."""
+    try:
+        resolved = Path(path).expanduser().resolve()
+        claude_dir = Path.home().joinpath(".claude").resolve()
+        return resolved.suffix == ".jsonl" and resolved.is_relative_to(claude_dir)
+    except Exception:
+        return False
 
 
 def compress_path(path: str, max_len: int = DEFAULT_PATH_MAX_LEN) -> str:

--- a/backend/app/core/summary_service.py
+++ b/backend/app/core/summary_service.py
@@ -1,12 +1,10 @@
 """AI-powered summary generation using Claude Haiku."""
 
-import json
 import logging
 import re
 from typing import Any
 
 from app.config import get_settings
-from app.core.path_utils import compress_path, compress_paths_in_text
 
 logger = logging.getLogger(__name__)
 
@@ -60,20 +58,6 @@ class SummaryService:
                 logger.info("Summary service disabled via SUMMARY_ENABLED=False")
             else:
                 logger.info("CLAUDE_CODE_OAUTH_TOKEN not set - using fallback summaries")
-
-    async def summarize_tool_call(self, tool_name: str, tool_input: dict[str, Any] | None) -> str:
-        """Generate a short summary of what a tool call does."""
-        fallback = self._get_tool_fallback(tool_name, tool_input)
-
-        if not self.enabled or not self.client:
-            return fallback
-
-        input_str = json.dumps(tool_input or {}, indent=2)[:500]
-
-        result = await self._call_with_retry(
-            f"In 10 words or less, what does this {tool_name} tool call do?\n{input_str}"
-        )
-        return result or fallback
 
     async def summarize_agent_task(self, task_description: str) -> str:
         """Generate a short summary of a subagent's task."""
@@ -442,50 +426,6 @@ class SummaryService:
             f"In 15 words or less, summarize this response:\n{text}"
         )
         return result or fallback
-
-    def _get_tool_fallback(self, tool_name: str, tool_input: dict[str, Any] | None) -> str:
-        """Generate a simple fallback summary for a tool call without AI."""
-        if not tool_input:
-            return tool_name
-
-        result: str | None = None
-
-        if tool_name in ("Read", "Glob", "Grep", "Write", "Edit"):
-            path = tool_input.get("file_path") or tool_input.get("pattern", "")
-            if path:
-                result = compress_path(path, max_len=35)
-
-        elif tool_name == "Bash":
-            cmd = tool_input.get("command", "")
-            if cmd:
-                cmd_clean = cmd.strip().split("\n")[0]
-                if len(cmd_clean) > 40:
-                    cmd_clean = f"{cmd_clean[:37]}..."
-                result = cmd_clean
-
-        elif tool_name in ("Task", "Agent"):
-            desc = tool_input.get("prompt") or tool_input.get("description", "")
-            if desc:
-                result = self._extract_first_sentence(desc, max_len=40)
-
-        elif tool_name == "WebSearch":
-            query = tool_input.get("query", "")
-            if query:
-                if len(query) > 35:
-                    query = f"{query[:32]}..."
-                result = f"Search: {query}"
-
-        elif tool_name == "WebFetch":
-            url = tool_input.get("url", "")
-            if url:
-                match = re.search(r"https?://([^/]+)", url)
-                if match:
-                    result = f"Fetch: {match.group(1)}"
-
-        if result:
-            return compress_paths_in_text(result)
-
-        return tool_name
 
     def _extract_first_sentence(self, text: str, max_len: int = 100) -> str:
         """Extract the first sentence as a fallback summary."""

--- a/backend/app/core/transcript_poller.py
+++ b/backend/app/core/transcript_poller.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from typing import Any, cast
 
 from app.config import get_settings
+from app.core.path_utils import is_safe_transcript_path
 from app.models.common import BubbleContent, BubbleType
 from app.models.events import Event, EventData, EventType
 
@@ -56,6 +57,10 @@ class TranscriptPoller:
         settings = get_settings()
         translated_path = settings.translate_path(transcript_path)
         path = Path(translated_path).expanduser()
+
+        if not is_safe_transcript_path(path):
+            logger.warning(f"Rejected transcript path outside ~/.claude/: {translated_path}")
+            return
 
         async with self._lock:
             if agent_id in self._agents:
@@ -186,6 +191,10 @@ class TranscriptPoller:
         events: list[Event] = []
 
         if not agent.transcript_path.exists():
+            return events
+
+        if not is_safe_transcript_path(agent.transcript_path):
+            logger.warning(f"Rejected transcript path outside ~/.claude/: {agent.transcript_path}")
             return events
 
         try:

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -54,6 +54,31 @@ class LocalhostOnlyMiddleware(BaseHTTPMiddleware):
         return await call_next(request)
 
 
+# Paths that do NOT require an API key (health checks, static assets, etc.)
+_NO_AUTH_PATHS = frozenset({"/health", "/docs", "/openapi.json"})
+
+
+class ApiKeyMiddleware(BaseHTTPMiddleware):
+    """Validate X-API-Key header when CLAUDE_OFFICE_API_KEY is configured.
+
+    When the key is empty (default), auth is skipped for backwards compatibility.
+    """
+
+    async def dispatch(self, request: Request, call_next):  # type: ignore[override]
+        key = settings.CLAUDE_OFFICE_API_KEY
+        if not key:
+            return await call_next(request)
+
+        if request.url.path in _NO_AUTH_PATHS or request.url.path.startswith("/ws/"):
+            return await call_next(request)
+
+        provided = request.headers.get("X-API-Key", "")
+        if provided != key:
+            return JSONResponse(status_code=401, content={"detail": "Invalid API key"})
+
+        return await call_next(request)
+
+
 logging.basicConfig(
     level=logging.INFO, format="%(message)s", handlers=[RichHandler(rich_tracebacks=True)]
 )
@@ -149,6 +174,7 @@ app.add_middleware(
 )
 
 app.add_middleware(LocalhostOnlyMiddleware)
+app.add_middleware(ApiKeyMiddleware)
 
 app.include_router(events.router, prefix=f"{settings.API_V1_STR}")
 app.include_router(floors.router, prefix=f"{settings.API_V1_STR}")

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -10,6 +10,7 @@ import asyncio
 import tempfile
 from collections.abc import AsyncIterator, Iterator
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 import pytest_asyncio
@@ -80,6 +81,27 @@ def _reset_rate_limiter() -> None:  # pyright: ignore[reportUnusedFunction]
     from app.api.routes.events import reset_rate_limiter
 
     reset_rate_limiter()
+
+
+@pytest.fixture(autouse=True)
+def _allow_test_transcript_paths() -> Iterator[None]:  # pyright: ignore[reportUnusedFunction]
+    """Allow transcript reads from temp directories in tests.
+
+    Production code validates that transcript paths are under ~/.claude/,
+    but tests use temp directories. Patch is_safe_transcript_path to always
+    return True so existing tests don't need to change.
+    """
+    from contextlib import ExitStack
+
+    with ExitStack() as stack:
+        for target in (
+            "app.core.path_utils.is_safe_transcript_path",
+            "app.core.jsonl_parser.is_safe_transcript_path",
+            "app.core.transcript_poller.is_safe_transcript_path",
+            "app.core.handlers.conversation_handler.is_safe_transcript_path",
+        ):
+            stack.enter_context(patch(target, return_value=True))
+        yield
 
 
 @pytest.fixture

--- a/backend/tests/test_security_hardening.py
+++ b/backend/tests/test_security_hardening.py
@@ -1,0 +1,267 @@
+"""Tests for security hardening (issue #37)."""
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+from urllib.parse import urlparse
+
+from fastapi.testclient import TestClient
+
+from app.api.websocket import validate_websocket_origin
+from app.core.path_utils import is_safe_transcript_path
+
+# ---------------------------------------------------------------------------
+# Fix #1: API URL validation — tests the validation logic directly
+# (hooks-side module reload can't run from backend test env)
+# ---------------------------------------------------------------------------
+
+_ALLOWED_HOSTNAMES = frozenset({"localhost", "127.0.0.1", "::1", None})
+
+
+class TestApiUrlValidation:
+    """Verify the hostname allowlist used by hooks config."""
+
+    def test_localhost_hostname_allowed(self) -> None:
+        assert urlparse("http://localhost:8000/api").hostname in _ALLOWED_HOSTNAMES
+
+    def test_127_hostname_allowed(self) -> None:
+        assert urlparse("http://127.0.0.1:8000/api").hostname in _ALLOWED_HOSTNAMES
+
+    def test_ipv6_hostname_allowed(self) -> None:
+        assert urlparse("http://[::1]:8000/api").hostname in _ALLOWED_HOSTNAMES
+
+    def test_external_hostname_blocked(self) -> None:
+        assert urlparse("https://evil.com/collect").hostname not in _ALLOWED_HOSTNAMES
+
+    def test_lan_ip_blocked(self) -> None:
+        assert urlparse("http://192.168.1.1:8000/api").hostname not in _ALLOWED_HOSTNAMES
+
+
+# ---------------------------------------------------------------------------
+# Fix #2: Transcript path validation
+# ---------------------------------------------------------------------------
+
+
+class TestSafeTranscriptPath:
+    """Verify is_safe_transcript_path rejects paths outside ~/.claude/."""
+
+    def test_valid_claude_jsonl(self) -> None:
+        with patch.object(Path, "home", return_value=Path("/home/user")):
+            assert is_safe_transcript_path("/home/user/.claude/session.jsonl") is True
+
+    def test_rejects_non_claude_dir(self) -> None:
+        with patch.object(Path, "home", return_value=Path("/home/user")):
+            assert is_safe_transcript_path("/tmp/evil.jsonl") is False
+
+    def test_rejects_non_jsonl(self) -> None:
+        with patch.object(Path, "home", return_value=Path("/home/user")):
+            assert is_safe_transcript_path("/home/user/.claude/config.env") is False
+
+    def test_rejects_path_traversal(self) -> None:
+        with patch.object(Path, "home", return_value=Path("/home/user")):
+            assert is_safe_transcript_path("/home/user/.claude/../../etc/passwd.jsonl") is False
+
+    def test_rejects_empty(self) -> None:
+        assert is_safe_transcript_path("") is False
+
+
+# ---------------------------------------------------------------------------
+# Fix #3: API key auth middleware
+# ---------------------------------------------------------------------------
+
+
+class TestApiKeyMiddleware:
+    """Verify ApiKeyMiddleware rejects requests without valid key."""
+
+    def test_no_key_configured_allows_requests(self) -> None:
+        """When CLAUDE_OFFICE_API_KEY is empty, auth is skipped."""
+        from app.main import app
+
+        client = TestClient(app)
+        resp = client.post(
+            "/api/v1/events",
+            json={
+                "event_type": "session_start",
+                "session_id": "test-no-key",
+                "timestamp": "2026-01-01T00:00:00",
+                "data": {},
+            },
+        )
+        assert resp.status_code == 200
+
+    def test_valid_key_accepted(self) -> None:
+        """Requests with the correct X-API-Key should pass."""
+        from app.config import get_settings
+
+        settings = get_settings()
+        original_key = settings.CLAUDE_OFFICE_API_KEY
+        settings.CLAUDE_OFFICE_API_KEY = "test-secret-key"
+
+        from app.main import app
+
+        try:
+            client = TestClient(app)
+            resp = client.post(
+                "/api/v1/events",
+                json={
+                    "event_type": "session_start",
+                    "session_id": "test-with-key",
+                    "timestamp": "2026-01-01T00:00:00",
+                    "data": {},
+                },
+                headers={"X-API-Key": "test-secret-key"},
+            )
+            assert resp.status_code == 200
+        finally:
+            settings.CLAUDE_OFFICE_API_KEY = original_key
+
+    def test_invalid_key_rejected(self) -> None:
+        """Requests with wrong X-API-Key should get 401."""
+        from app.config import get_settings
+
+        settings = get_settings()
+        original_key = settings.CLAUDE_OFFICE_API_KEY
+        settings.CLAUDE_OFFICE_API_KEY = "test-secret-key"
+
+        from app.main import app
+
+        try:
+            client = TestClient(app)
+            resp = client.post(
+                "/api/v1/events",
+                json={
+                    "event_type": "session_start",
+                    "session_id": "test-bad-key",
+                    "timestamp": "2026-01-01T00:00:00",
+                    "data": {},
+                },
+                headers={"X-API-Key": "wrong-key"},
+            )
+            assert resp.status_code == 401
+        finally:
+            settings.CLAUDE_OFFICE_API_KEY = original_key
+
+    def test_missing_key_rejected(self) -> None:
+        """Requests with no X-API-Key when key is configured should get 401."""
+        from app.config import get_settings
+
+        settings = get_settings()
+        original_key = settings.CLAUDE_OFFICE_API_KEY
+        settings.CLAUDE_OFFICE_API_KEY = "test-secret-key"
+
+        from app.main import app
+
+        try:
+            client = TestClient(app)
+            resp = client.post(
+                "/api/v1/events",
+                json={
+                    "event_type": "session_start",
+                    "session_id": "test-no-key-header",
+                    "timestamp": "2026-01-01T00:00:00",
+                    "data": {},
+                },
+            )
+            assert resp.status_code == 401
+        finally:
+            settings.CLAUDE_OFFICE_API_KEY = original_key
+
+    def test_health_endpoint_skips_auth(self) -> None:
+        """Health endpoint should not require an API key."""
+        from app.config import get_settings
+
+        settings = get_settings()
+        original_key = settings.CLAUDE_OFFICE_API_KEY
+        settings.CLAUDE_OFFICE_API_KEY = "test-secret-key"
+
+        from app.main import app
+
+        try:
+            client = TestClient(app)
+            resp = client.get("/health")
+            assert resp.status_code == 200
+        finally:
+            settings.CLAUDE_OFFICE_API_KEY = original_key
+
+
+# ---------------------------------------------------------------------------
+# Fix #4: WebSocket origin validation with API key fallback
+# ---------------------------------------------------------------------------
+
+
+class TestWebSocketOriginValidation:
+    """Verify WebSocket validates both origin and API key."""
+
+    def _make_ws(self, origin: str | None = None, api_key: str | None = None) -> Any:
+        """Create a mock WebSocket with specified headers."""
+
+        class MockWebSocket:
+            def __init__(self, headers: dict[str, str]) -> None:
+                self.headers = headers
+
+        headers: dict[str, str] = {}
+        if origin is not None:
+            headers["origin"] = origin
+        if api_key is not None:
+            headers["x-api-key"] = api_key
+        return MockWebSocket(headers)
+
+    def test_localhost_origin_accepted(self) -> None:
+        ws = self._make_ws(origin="http://localhost:3000")
+        assert validate_websocket_origin(ws) is True
+
+    def test_external_origin_rejected(self) -> None:
+        ws = self._make_ws(origin="https://evil.com")
+        assert validate_websocket_origin(ws) is False
+
+    def test_no_origin_no_key_configured_accepted(self) -> None:
+        """No origin + no API key configured = accepted (backwards compat)."""
+        from app.config import get_settings
+
+        settings = get_settings()
+        original = settings.CLAUDE_OFFICE_API_KEY
+        settings.CLAUDE_OFFICE_API_KEY = ""
+        try:
+            ws = self._make_ws()
+            assert validate_websocket_origin(ws) is True
+        finally:
+            settings.CLAUDE_OFFICE_API_KEY = original
+
+    def test_no_origin_valid_key_accepted(self) -> None:
+        """No origin + valid API key = accepted."""
+        from app.config import get_settings
+
+        settings = get_settings()
+        original = settings.CLAUDE_OFFICE_API_KEY
+        settings.CLAUDE_OFFICE_API_KEY = "my-secret"
+        try:
+            ws = self._make_ws(api_key="my-secret")
+            assert validate_websocket_origin(ws) is True
+        finally:
+            settings.CLAUDE_OFFICE_API_KEY = original
+
+    def test_no_origin_wrong_key_rejected(self) -> None:
+        """No origin + wrong API key = rejected."""
+        from app.config import get_settings
+
+        settings = get_settings()
+        original = settings.CLAUDE_OFFICE_API_KEY
+        settings.CLAUDE_OFFICE_API_KEY = "my-secret"
+        try:
+            ws = self._make_ws(api_key="wrong")
+            assert validate_websocket_origin(ws) is False
+        finally:
+            settings.CLAUDE_OFFICE_API_KEY = original
+
+    def test_no_origin_no_key_rejected(self) -> None:
+        """No origin + no API key when configured = rejected."""
+        from app.config import get_settings
+
+        settings = get_settings()
+        original = settings.CLAUDE_OFFICE_API_KEY
+        settings.CLAUDE_OFFICE_API_KEY = "my-secret"
+        try:
+            ws = self._make_ws()
+            assert validate_websocket_origin(ws) is False
+        finally:
+            settings.CLAUDE_OFFICE_API_KEY = original

--- a/backend/tests/test_summary_service.py
+++ b/backend/tests/test_summary_service.py
@@ -60,56 +60,6 @@ class TestExtractFirstSentence:
         assert len(result) > 10 or result == text[:50]
 
 
-class TestGetToolFallback:
-    """Tests for _get_tool_fallback method."""
-
-    def test_empty_input_returns_tool_name(self, service: SummaryService) -> None:
-        """Empty input should return just the tool name."""
-        assert service._get_tool_fallback("Read", None) == "Read"
-        assert service._get_tool_fallback("Write", {}) == "Write"
-
-    def test_read_tool_returns_path(self, service: SummaryService) -> None:
-        """Read tool should return compressed file path."""
-        result = service._get_tool_fallback("Read", {"file_path": "/tmp/test.txt"})
-        assert "test.txt" in result
-
-    def test_glob_tool_returns_pattern(self, service: SummaryService) -> None:
-        """Glob tool should return pattern."""
-        result = service._get_tool_fallback("Glob", {"pattern": "**/*.py"})
-        assert "**/*.py" in result
-
-    def test_bash_tool_returns_command(self, service: SummaryService) -> None:
-        """Bash tool should return first line of command."""
-        result = service._get_tool_fallback("Bash", {"command": "ls -la\necho done"})
-        assert result == "ls -la"
-
-    def test_bash_long_command_truncated(self, service: SummaryService) -> None:
-        """Long bash commands should be truncated."""
-        long_cmd = "a" * 100
-        result = service._get_tool_fallback("Bash", {"command": long_cmd})
-        assert len(result) <= 40
-        assert result.endswith("...")
-
-    def test_task_tool_returns_description(self, service: SummaryService) -> None:
-        """Task tool should return task description."""
-        result = service._get_tool_fallback(
-            "Task", {"prompt": "Run the tests and verify everything works correctly."}
-        )
-        assert "Run the tests" in result
-
-    def test_websearch_returns_query(self, service: SummaryService) -> None:
-        """WebSearch should return search query."""
-        result = service._get_tool_fallback("WebSearch", {"query": "python asyncio"})
-        assert result == "Search: python asyncio"
-
-    def test_webfetch_returns_domain(self, service: SummaryService) -> None:
-        """WebFetch should return domain name."""
-        result = service._get_tool_fallback(
-            "WebFetch", {"url": "https://docs.python.org/3/library/asyncio.html"}
-        )
-        assert result == "Fetch: docs.python.org"
-
-
 class TestGenerateAgentNameFallback:
     """Tests for generate_agent_name_fallback method."""
 

--- a/hooks/install.sh
+++ b/hooks/install.sh
@@ -42,6 +42,18 @@ fi
 # Create config directory if it doesn't exist
 mkdir -p "$(dirname "$CONFIG_FILE")"
 
+# Generate or reuse API key for backend authentication
+if [ -f "$CONFIG_FILE" ]; then
+    EXISTING_KEY=$(grep '^CLAUDE_OFFICE_API_KEY=' "$CONFIG_FILE" | head -1 | cut -d'=' -f2 | tr -d '"' | tr -d "'")
+fi
+if [ -n "$EXISTING_KEY" ]; then
+    API_KEY="$EXISTING_KEY"
+    echo "Reusing existing API key."
+else
+    API_KEY=$(python3 -c "import secrets; print(secrets.token_urlsafe(32))")
+    echo "Generated new API key."
+fi
+
 # Save configuration
 echo "Saving configuration to $CONFIG_FILE..."
 cat > "$CONFIG_FILE" << EOF
@@ -54,6 +66,9 @@ CLAUDE_OFFICE_STRIP_PREFIXES="$STRIP_PREFIXES"
 
 # Set to 1 to enable debug logging
 CLAUDE_OFFICE_DEBUG=0
+
+# API key for backend authentication
+CLAUDE_OFFICE_API_KEY="$API_KEY"
 EOF
 
 echo "Configuration saved."

--- a/hooks/src/claude_office_hooks/config.py
+++ b/hooks/src/claude_office_hooks/config.py
@@ -6,13 +6,33 @@ Output suppression is handled in main.py before this module is imported.
 
 import os
 from pathlib import Path
+from urllib.parse import urlparse
 
 # ---------------------------------------------------------------------------
 # API endpoint and request constants
 # ---------------------------------------------------------------------------
 
-API_URL = os.environ.get("CLAUDE_OFFICE_API_URL", "http://localhost:8000/api/v1/events")
+_LOCALHOST_HOSTNAMES = frozenset({"localhost", "127.0.0.1", "::1", None})
+
+_raw_api_url = os.environ.get("CLAUDE_OFFICE_API_URL", "http://localhost:8000/api/v1/events")
+_parsed_url = urlparse(_raw_api_url)
+if _parsed_url.hostname not in _LOCALHOST_HOSTNAMES:
+    _raw_api_url = "http://localhost:8000/api/v1/events"
+API_URL = _raw_api_url
+
+# Mutable holder for the API key — populated by load_config().
+_api_key_holder: list[str] = [""]
 TIMEOUT = 0.5  # Seconds — keep short so hooks never block Claude
+
+
+def get_api_key() -> str:
+    """Return the current API key (may be empty string before load_config)."""
+    return _api_key_holder[0]
+
+
+def _set_api_key(key: str) -> None:
+    _api_key_holder[0] = key
+
 
 # ---------------------------------------------------------------------------
 # Config file location
@@ -53,4 +73,6 @@ def load_config() -> dict[str, str]:
         except Exception:
             # Config loading must never raise — hooks must always exit 0
             pass
+    # Set API key from config or env var (env var takes precedence)
+    _set_api_key(os.environ.get("CLAUDE_OFFICE_API_KEY", config.get("CLAUDE_OFFICE_API_KEY", "")))
     return config

--- a/hooks/src/claude_office_hooks/main.py
+++ b/hooks/src/claude_office_hooks/main.py
@@ -29,7 +29,7 @@ try:
     import urllib.request
     from typing import Any, cast
 
-    from claude_office_hooks.config import API_URL, TIMEOUT, load_config
+    from claude_office_hooks.config import API_URL, TIMEOUT, get_api_key, load_config
     from claude_office_hooks.debug_logger import debug_log
     from claude_office_hooks.event_mapper import map_event
 
@@ -46,9 +46,11 @@ try:
         """
         try:
             json_data = json.dumps(payload).encode("utf-8")
-            req = urllib.request.Request(
-                API_URL, data=json_data, headers={"Content-Type": "application/json"}
-            )
+            headers: dict[str, str] = {"Content-Type": "application/json"}
+            api_key = get_api_key()
+            if api_key:
+                headers["X-API-Key"] = api_key
+            req = urllib.request.Request(API_URL, data=json_data, headers=headers)
             with urllib.request.urlopen(req, timeout=TIMEOUT) as response:
                 if response.status >= 300:
                     pass  # Silently fail — never disrupt the user

--- a/hooks/uninstall.sh
+++ b/hooks/uninstall.sh
@@ -11,4 +11,12 @@ echo "Uninstalling hooks..."
 # Use the python script to remove settings
 uv run -p 3.14 "$HOOKS_DIR/manage_hooks.py" uninstall --hook-cmd "$HOOK_CMD"
 
+# Remove the installed tool binary
+echo "Removing claude-office-hook tool..."
+uv tool uninstall claude-office-hook 2>/dev/null || true
+
+# Clean up config and log files
+rm -f "$HOME/.claude/claude-office-config.env"
+rm -f "$HOME/.claude/claude-office-hooks.log"
+
 echo "Done! Hooks removed from configuration."

--- a/uv.lock
+++ b/uv.lock
@@ -70,7 +70,7 @@ wheels = [
 
 [[package]]
 name = "claude-office"
-version = "0.15.0"
+version = "0.16.0"
 source = { editable = "." }
 dependencies = [
     { name = "requests" },


### PR DESCRIPTION
## Summary

Closes #37 — addresses all 6 security hardening findings from code audit.

| # | Finding | Severity | Status |
|---|---------|----------|--------|
| 1 | `CLAUDE_OFFICE_API_URL` not validated for localhost | High | Fixed |
| 2 | No path validation on `transcript_path` file reads | High | Fixed |
| 3 | No API auth beyond localhost check | Medium | Fixed |
| 4 | WebSocket origin bypass via missing header | Medium | Fixed (by #3) |
| 5 | Incomplete `uninstall.sh` leaves files behind | Low | Fixed |
| 6 | Dead code: `summarize_tool_call()` | Info | Fixed |

### Changes

- **Hooks config** (`hooks/src/claude_office_hooks/config.py`): Validates API URL hostname is localhost/127.0.0.1/::1, falls back to safe default. Loads API key from config file.
- **Hooks main** (`hooks/src/claude_office_hooks/main.py`): Sends `X-API-Key` header with event payloads.
- **Install script** (`hooks/install.sh`): Auto-generates 32-byte API key at install, reuses on reinstall.
- **Uninstall script** (`hooks/uninstall.sh`): Now removes tool binary, config file, and debug log.
- **Backend config** (`backend/app/config.py`): New `CLAUDE_OFFICE_API_KEY` setting (empty = auth skipped for backwards compat).
- **Backend middleware** (`backend/app/main.py`): New `ApiKeyMiddleware` validates `X-API-Key` header when configured. Health endpoint and WebSocket paths are exempt.
- **Transcript path validation** (`backend/app/core/path_utils.py`): New `is_safe_transcript_path()` — validates paths are under `~/.claude/` with `.jsonl` extension. Applied in `jsonl_parser.py`, `transcript_poller.py`, and `conversation_handler.py`.
- **WebSocket** (`backend/app/api/websocket.py`): Non-browser connections (no `Origin` header) must present valid API key.
- **Dead code** (`backend/app/core/summary_service.py`): Removed `summarize_tool_call()` and `_get_tool_fallback()` (unused).

### Test plan

- [x] 21 new tests in `test_security_hardening.py` covering URL validation, path validation, API key middleware, and WebSocket origin checks
- [x] All 277 backend tests pass
- [x] `make checkall` passes (lint, typecheck, test)
- [x] Pre-commit hooks pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Optional API key authentication for hook requests, auto-generated during installation
  * Enhanced API URL validation restricting connections to localhost only
  * Transcript file access now restricted to designated directories with proper file validation
  * Improved WebSocket connection security for non-browser clients

* **Bug Fixes**
  * Fixed uninstall process to properly remove installed tools and configuration files

* **Tests**
  * Added comprehensive security hardening test suite

* **Chores**
  * Removed unused code fragments

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/paulrobello/claude-office/pull/38?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->