### PR TITLE
feat: Command Center — cross-terminal session overview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to Claude Office Visualizer are documented here.
 
+## [0.20.0] - 2026-06-11
+
+### Added
+
+- **Command Center (cross-terminal overview)**: a new top-level view that gathers the boss (main agent) of every live session into a single pixel canvas, so you can see at a glance what's finished, what's still running, and what needs your attention. Reachable from a header button (when ≥2 active sessions) and a penthouse tile in the Building view
+  - **Open-plan layout** matching the main office: a decorated top wall (Employee-of-the-Month posters, outlets), a checkerboard tiled floor, and four status **columns** left→right by priority — Needs-you, Working, Done, Ended. Each agent appears as a character at a **fixed** spot in its column with its project nameplate, a `+N` active-subagent badge, and a todo progress bar. Agents **walk** to their seats (A* pathfinding **around** the furniture) and take any **free** seat — no reserved spots and no reshuffling when others come or go; furniture is static (never follows agents). Needs-you/Working are rows of **desks** (chair + desk + monitor, from the office sprites); **Done is a lounge** with couches; **Ended** is an **EXIT** — the office elevator doorway with an EXIT sign. When a session finishes (terminal closes) while you're watching, its agent walks to the elevator, the doors open, and it steps out and is gone (sessions already finished before the view opened are not shown). The top wall carries an **ALL SESSIONS board** with combined stats (terminal count, per-status counts, total employees, aggregate todo progress) and a **wall clock** (reused from the office); a row of reused furniture (plants, printer, water cooler, coffee machine) lines the bottom wall
+  - Backend: new `OverviewEntry`/`OverviewState` models, `build_overview()` peer merge in `room_orchestrator`, and a `/ws/overview` WebSocket broadcasting one boss snapshot per live session (rebuilt only when a client is watching)
+  - Frontend: `command` view mode, `overviewStore` + `useOverviewWebSocket`, and a sibling PixiJS canvas reusing the office sprites/textures. Clicking an agent opens a cross-session popover to **open that agent's terminal** or **drill in** to its office
+- **Scrollable Building view**: the building cross-section now scrolls when the floor list is taller than the viewport, while still centering when it fits
+
 ## [0.19.0] - 2026-06-02
 
 ### Security

--- a/backend/app/api/websocket.py
+++ b/backend/app/api/websocket.py
@@ -56,6 +56,7 @@ class ConnectionManager:
     def __init__(self) -> None:
         self.active_connections: dict[str, list[WebSocket]] = {}
         self.room_connections: dict[str, list[WebSocket]] = {}
+        self.overview_connections: list[WebSocket] = []
         self._lock = asyncio.Lock()
 
     # ------------------------------------------------------------------
@@ -198,6 +199,45 @@ class ConnectionManager:
             return
 
         await self._broadcast_to_connections(message, connections, self.room_connections, room_id)
+
+    # ------------------------------------------------------------------
+    # Overview-level WebSocket support (Command Center — cross-session)
+    # ------------------------------------------------------------------
+
+    async def connect_overview(self, websocket: WebSocket) -> None:
+        """Accept a WebSocket connection and register it for the overview feed."""
+        await websocket.accept()
+        async with self._lock:
+            self.overview_connections.append(websocket)
+
+    async def disconnect_overview(self, websocket: WebSocket) -> None:
+        """Remove a WebSocket connection from the overview feed."""
+        async with self._lock:
+            if websocket in self.overview_connections:
+                self.overview_connections.remove(websocket)
+
+    async def broadcast_overview(self, message: dict[str, Any]) -> None:
+        """Send a message to all WebSocket clients on the overview feed."""
+        async with self._lock:
+            connections = self.overview_connections.copy()
+
+        if not connections:
+            return
+
+        failed: list[WebSocket] = []
+        for connection in connections:
+            try:
+                if connection.client_state == WebSocketState.CONNECTED:
+                    await connection.send_json(message)
+            except Exception as e:
+                logger.warning("Failed to send to overview WebSocket: %s", e)
+                failed.append(connection)
+
+        if failed:
+            async with self._lock:
+                for conn in failed:
+                    if conn in self.overview_connections:
+                        self.overview_connections.remove(conn)
 
 
 manager = ConnectionManager()

--- a/backend/app/core/broadcast_service.py
+++ b/backend/app/core/broadcast_service.py
@@ -22,6 +22,7 @@ __all__ = [
     "broadcast_event",
     "broadcast_error",
     "broadcast_room_state",
+    "broadcast_overview_state",
 ]
 
 
@@ -91,4 +92,25 @@ async def broadcast_room_state(room_id: str, orchestrator: RoomOrchestrator) -> 
             "state": merged_state.model_dump(mode="json", by_alias=True),
         },
         room_id,
+    )
+
+
+async def broadcast_overview_state(sessions: dict[str, StateMachine]) -> None:
+    """Broadcast the cross-session overview to all ``/ws/overview`` clients.
+
+    Skips building the payload entirely when nobody is watching the Command
+    Center, so the per-event hook stays cheap in the common case.
+    """
+    if not manager.overview_connections:
+        return
+    # Local import avoids any import-order coupling at module load.
+    from app.core.room_orchestrator import build_overview
+
+    overview = build_overview(sessions)
+    await manager.broadcast_overview(
+        {
+            "type": "state_update",
+            "timestamp": overview.last_updated.isoformat(),
+            "state": overview.model_dump(mode="json", by_alias=True),
+        }
     )

--- a/backend/app/core/broadcast_service.py
+++ b/backend/app/core/broadcast_service.py
@@ -8,6 +8,7 @@ full EventProcessor class.
 
 from __future__ import annotations
 
+import asyncio
 from typing import TYPE_CHECKING, Any
 
 from app.api.websocket import manager
@@ -95,18 +96,32 @@ async def broadcast_room_state(room_id: str, orchestrator: RoomOrchestrator) -> 
     )
 
 
-async def broadcast_overview_state(sessions: dict[str, StateMachine]) -> None:
+async def broadcast_overview_state(
+    sessions: dict[str, StateMachine],
+    sessions_lock: asyncio.Lock | None = None,
+) -> None:
     """Broadcast the cross-session overview to all ``/ws/overview`` clients.
 
     Skips building the payload entirely when nobody is watching the Command
     Center, so the per-event hook stays cheap in the common case.
+
+    ``build_overview`` reads the live session registry and each StateMachine's
+    mutable collections, which concurrent event handlers rewrite (e.g.
+    ``self.sessions[id] = ...`` / ``del sm.agents[id]``). When *sessions_lock*
+    is supplied it is held across the build so the registry can't be resized
+    mid-iteration. Callers must NOT already hold the lock (it is acquired here
+    exactly once, so there is no re-entry / deadlock risk).
     """
     if not manager.overview_connections:
         return
     # Local import avoids any import-order coupling at module load.
     from app.core.room_orchestrator import build_overview
 
-    overview = build_overview(sessions)
+    if sessions_lock is not None:
+        async with sessions_lock:
+            overview = build_overview(sessions)
+    else:
+        overview = build_overview(sessions)
     await manager.broadcast_overview(
         {
             "type": "state_update",

--- a/backend/app/core/event_processor.py
+++ b/backend/app/core/event_processor.py
@@ -18,6 +18,7 @@ from typing import Any
 from sqlalchemy import delete, select
 from sqlalchemy.dialects.sqlite import insert as sqlite_insert
 
+from app.api.websocket import manager
 from app.config import get_settings
 from app.core.beads_poller import get_beads_poller, has_beads, init_beads_poller
 from app.core.broadcast_service import (
@@ -56,6 +57,7 @@ from app.db.models import EventRecord, SessionRecord
 from app.models.agents import AgentState
 from app.models.common import TodoItem
 from app.models.events import Event, EventData, EventType
+from app.models.overview import OverviewState
 from app.models.sessions import ConversationEntry, GameState, HistoryEntry
 from app.services.git_service import git_service
 
@@ -167,6 +169,11 @@ class EventProcessor:
         self._task_poller_initialized = False
         self._beads_poller_initialized = False
         self._beads_sessions: set[str] = set()  # Sessions with active beads polling
+        # Coalesces Command Center overview broadcasts: bursts of events schedule
+        # a single deferred flush instead of rebuilding the full peer-merge once
+        # per event (O(N x events/sec)). See ``_schedule_overview_broadcast``.
+        self._overview_flush_task: asyncio.Task[None] | None = None
+        self._overview_flush_interval = 0.05  # 50 ms debounce window
 
     # ------------------------------------------------------------------
     # Poller lifecycle helpers
@@ -532,12 +539,54 @@ class EventProcessor:
             await handle_teammate_idle(sm, event)
 
         # ------------------------------------------------------------------
-        # Cross-session overview broadcast (Command Center). Fired LAST so it
-        # reflects the field mutations applied by the event-type-specific
-        # handlers above (e.g. boss_current_task, agents) instead of lagging by
-        # one event. No-op when no one is watching /ws/overview.
+        # Cross-session overview broadcast (Command Center). Scheduled LAST so
+        # it reflects the field mutations applied by the event-type-specific
+        # handlers above (e.g. boss_current_task, agents). Debounced so a burst
+        # of events produces at most one broadcast per ~50 ms instead of one per
+        # event. No-op when no one is watching /ws/overview.
         # ------------------------------------------------------------------
-        await broadcast_overview_state(self.sessions)
+        self._schedule_overview_broadcast()
+
+    # ------------------------------------------------------------------
+    # Command Center overview (debounced cross-session broadcast)
+    # ------------------------------------------------------------------
+
+    def _schedule_overview_broadcast(self) -> None:
+        """Coalesce overview broadcasts into one deferred flush per ~50 ms.
+
+        Without watchers the build is skipped entirely (cheap no-op), so the
+        early ``overview_connections`` guard is preserved. When a flush is
+        already pending we let it run instead of stacking tasks: the pending
+        flush rebuilds from ``self.sessions`` at fire time, so it always
+        captures the final state of the burst (no dropped updates).
+        """
+        if not manager.overview_connections:
+            return
+        if self._overview_flush_task is not None and not self._overview_flush_task.done():
+            return
+        self._overview_flush_task = asyncio.create_task(self._flush_overview_broadcast())
+
+    async def _flush_overview_broadcast(self) -> None:
+        """Wait out the debounce window, then broadcast a single overview."""
+        try:
+            await asyncio.sleep(self._overview_flush_interval)
+            await broadcast_overview_state(self.sessions, self._sessions_lock)
+        except asyncio.CancelledError:  # pragma: no cover - shutdown path
+            raise
+        except Exception as e:
+            logger.exception(f"Error broadcasting overview state: {e}")
+
+    async def build_overview_snapshot(self) -> OverviewState:
+        """Build a cross-session overview under ``_sessions_lock``.
+
+        Used by the ``/ws/overview`` connect path so the initial snapshot reads a
+        consistent registry (no concurrent resize) without the caller touching
+        the private lock directly.
+        """
+        from app.core.room_orchestrator import build_overview
+
+        async with self._sessions_lock:
+            return build_overview(self.sessions)
 
     # ------------------------------------------------------------------
     # DB helpers

--- a/backend/app/core/event_processor.py
+++ b/backend/app/core/event_processor.py
@@ -366,7 +366,10 @@ class EventProcessor:
             if event.session_id not in self.sessions:
                 self.sessions[event.session_id] = StateMachine()
 
-        sm = self.sessions[event.session_id]
+            # Capture the StateMachine reference while still holding the lock so a
+            # concurrent clear_all_sessions()/remove_session() can't drop the key
+            # between this lookup and use (which would raise KeyError).
+            sm = self.sessions[event.session_id]
 
         sm.transition(event)
 
@@ -470,12 +473,6 @@ class EventProcessor:
             await broadcast_room_state(sm.room_id, orchestrator)
 
         # ------------------------------------------------------------------
-        # Cross-session overview broadcast (Command Center). No-op when no one
-        # is watching /ws/overview.
-        # ------------------------------------------------------------------
-        await broadcast_overview_state(self.sessions)
-
-        # ------------------------------------------------------------------
         # SUBAGENT_START
         # ------------------------------------------------------------------
         if event.event_type == EventType.SUBAGENT_START:
@@ -533,6 +530,14 @@ class EventProcessor:
 
         if event.event_type == EventType.TEAMMATE_IDLE:
             await handle_teammate_idle(sm, event)
+
+        # ------------------------------------------------------------------
+        # Cross-session overview broadcast (Command Center). Fired LAST so it
+        # reflects the field mutations applied by the event-type-specific
+        # handlers above (e.g. boss_current_task, agents) instead of lagging by
+        # one event. No-op when no one is watching /ws/overview.
+        # ------------------------------------------------------------------
+        await broadcast_overview_state(self.sessions)
 
     # ------------------------------------------------------------------
     # DB helpers

--- a/backend/app/core/event_processor.py
+++ b/backend/app/core/event_processor.py
@@ -23,6 +23,7 @@ from app.core.beads_poller import get_beads_poller, has_beads, init_beads_poller
 from app.core.broadcast_service import (
     broadcast_error,
     broadcast_event,
+    broadcast_overview_state,
     broadcast_room_state,
     broadcast_state,
 )
@@ -467,6 +468,12 @@ class EventProcessor:
                 self.orchestrators[sm.room_id] = orchestrator
             orchestrator.update_session(event.session_id, sm)
             await broadcast_room_state(sm.room_id, orchestrator)
+
+        # ------------------------------------------------------------------
+        # Cross-session overview broadcast (Command Center). No-op when no one
+        # is watching /ws/overview.
+        # ------------------------------------------------------------------
+        await broadcast_overview_state(self.sessions)
 
         # ------------------------------------------------------------------
         # SUBAGENT_START

--- a/backend/app/core/room_orchestrator.py
+++ b/backend/app/core/room_orchestrator.py
@@ -72,7 +72,12 @@ def _overview_bucket(sm: StateMachine) -> OverviewBucket:
     its turn is in progress (``turn_active``) or it has live subagents — only a
     genuinely finished/waiting turn lands in "done".
     """
-    bucket = _BOSS_TO_BUCKET.get(sm.boss_state, "working")
+    bucket = _BOSS_TO_BUCKET.get(sm.boss_state)
+    if bucket is None:
+        # An unknown BossState should fail safe to "done" rather than silently
+        # masking the session as "working"; flag it so the map can be updated.
+        logger.warning("No overview bucket for BossState %s; defaulting to 'done'", sm.boss_state)
+        bucket = "done"
     if bucket == "done" and (sm.turn_active or sm.agents):
         return "working"
     return bucket
@@ -313,11 +318,16 @@ def build_overview(sessions: dict[str, StateMachine]) -> OverviewState:
     "ended" bucket from its session list, so neither is included here.
     """
     entries: list[OverviewEntry] = []
-    # Snapshot: the live session registry may be mutated concurrently while
-    # events are processed for other sessions.
+    # Snapshot the registry up front: the caller holds ``_sessions_lock`` so the
+    # dict can't be resized mid-iteration here, but copy defensively in case a
+    # caller passes an unlocked registry.
     for session_id, sm in list(sessions.items()):
-        todo_total = len(sm.todos)
-        todo_done = sum(1 for t in sm.todos if t.status == TodoStatus.COMPLETED)
+        # Snapshot each StateMachine's mutable collections so an in-place
+        # mutation by that session's handlers (e.g. ``del sm.agents[id]``)
+        # can't raise "dict changed size during iteration" / torn counts.
+        todos = list(sm.todos)
+        todo_total = len(todos)
+        todo_done = sum(1 for t in todos if t.status == TodoStatus.COMPLETED)
         entries.append(
             OverviewEntry(
                 session_id=session_id,
@@ -326,7 +336,7 @@ def build_overview(sessions: dict[str, StateMachine]) -> OverviewState:
                 current_task=sm.boss_current_task,
                 todo_done=todo_done,
                 todo_total=todo_total,
-                subagent_count=len(sm.agents),
+                subagent_count=len(list(sm.agents)),
             )
         )
     return OverviewState(entries=entries, last_updated=datetime.now(UTC))

--- a/backend/app/core/room_orchestrator.py
+++ b/backend/app/core/room_orchestrator.py
@@ -15,6 +15,8 @@ from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
 from app.models.agents import Agent, AgentState, BossState, OfficeState
+from app.models.common import TodoStatus
+from app.models.overview import OverviewBucket, OverviewEntry, OverviewState
 from app.models.sessions import GameState, KanbanTask, WhiteboardData
 
 if TYPE_CHECKING:
@@ -43,6 +45,20 @@ _BOSS_TO_AGENT: dict[BossState, AgentState] = {
     BossState.WAITING_PERMISSION: AgentState.WAITING_PERMISSION,
     BossState.REVIEWING: AgentState.WORKING,
     BossState.COMPLETING: AgentState.COMPLETED,
+}
+
+# Maps BossState to a Command Center status bucket. "needs_you" surfaces the
+# terminals that are blocked on the user; "done" covers idle/finished turns.
+_BOSS_TO_BUCKET: dict[BossState, OverviewBucket] = {
+    BossState.WAITING_PERMISSION: "needs_you",
+    BossState.PHONE_RINGING: "needs_you",
+    BossState.WORKING: "working",
+    BossState.DELEGATING: "working",
+    BossState.REVIEWING: "working",
+    BossState.RECEIVING: "working",
+    BossState.ON_PHONE: "working",
+    BossState.IDLE: "done",
+    BossState.COMPLETING: "done",
 }
 
 
@@ -266,3 +282,35 @@ class RoomOrchestrator:
             ):
                 task.status = "in_progress"
                 promoted.add(task.assignee)
+
+
+# ----------------------------------------------------------------------
+# Command Center overview (cross-session, peer merge — no lead, no desks)
+# ----------------------------------------------------------------------
+
+
+def build_overview(sessions: dict[str, StateMachine]) -> OverviewState:
+    """Build a compact cross-session overview for the Command Center.
+
+    Every session is an equal peer: one boss snapshot each, mapped to a status
+    bucket. The frontend joins ``session_id`` to a project label and applies the
+    "ended" bucket from its session list, so neither is included here.
+    """
+    entries: list[OverviewEntry] = []
+    # Snapshot: the live session registry may be mutated concurrently while
+    # events are processed for other sessions.
+    for session_id, sm in list(sessions.items()):
+        todo_total = len(sm.todos)
+        todo_done = sum(1 for t in sm.todos if t.status == TodoStatus.COMPLETED)
+        entries.append(
+            OverviewEntry(
+                session_id=session_id,
+                bucket=_BOSS_TO_BUCKET.get(sm.boss_state, "working"),
+                state=sm.boss_state,
+                current_task=sm.boss_current_task,
+                todo_done=todo_done,
+                todo_total=todo_total,
+                subagent_count=len(sm.agents),
+            )
+        )
+    return OverviewState(entries=entries, last_updated=datetime.now(UTC))

--- a/backend/app/core/room_orchestrator.py
+++ b/backend/app/core/room_orchestrator.py
@@ -62,6 +62,22 @@ _BOSS_TO_BUCKET: dict[BossState, OverviewBucket] = {
 }
 
 
+def _overview_bucket(sm: StateMachine) -> OverviewBucket:
+    """Pick the Command Center zone for a session, smoothing out flicker.
+
+    The boss drops to ``IDLE`` in the brief gap *between* tool calls and right
+    after a subagent stops, even though the turn is still running. Mapping that
+    transient idle straight to "done" makes the terminal jump out of the working
+    zone and back every tool cycle. So a session counts as still working when
+    its turn is in progress (``turn_active``) or it has live subagents — only a
+    genuinely finished/waiting turn lands in "done".
+    """
+    bucket = _BOSS_TO_BUCKET.get(sm.boss_state, "working")
+    if bucket == "done" and (sm.turn_active or sm.agents):
+        return "working"
+    return bucket
+
+
 @dataclass
 class _SessionEntry:
     session_id: str
@@ -305,7 +321,7 @@ def build_overview(sessions: dict[str, StateMachine]) -> OverviewState:
         entries.append(
             OverviewEntry(
                 session_id=session_id,
-                bucket=_BOSS_TO_BUCKET.get(sm.boss_state, "working"),
+                bucket=_overview_bucket(sm),
                 state=sm.boss_state,
                 current_task=sm.boss_current_task,
                 todo_done=todo_done,

--- a/backend/app/core/state_machine.py
+++ b/backend/app/core/state_machine.py
@@ -203,6 +203,7 @@ def _handle_session_start(sm: "StateMachine", event: Event) -> None:
     """Handle SESSION_START: initialize office state for a new session."""
     sm.phase = OfficePhase.STARTING
     sm.boss_state = BossState.IDLE
+    sm.turn_active = False
     sm.whiteboard.reset()
     sm.whiteboard.add_news_item("session", "New session started - ready for work!")
 
@@ -261,6 +262,7 @@ def _handle_user_prompt_submit(sm: "StateMachine", event: Event) -> None:
     sm.boss_state = BossState.RECEIVING
     prompt_text = event.data.prompt if event.data else ""
     sm.print_report = False
+    sm.turn_active = True
     sm.last_user_prompt = prompt_text
     if prompt_text:
         sm.boss_bubble = BubbleContent(
@@ -380,6 +382,7 @@ def _handle_stop(sm: "StateMachine", event: Event) -> None:
     """Handle STOP: main agent completes work, show completion message."""
     sm.phase = OfficePhase.COMPLETING
     sm.boss_state = BossState.COMPLETING
+    sm.turn_active = False
 
     speech_text = (
         event.data.speech_content.boss_phone
@@ -401,6 +404,7 @@ def _handle_session_end(sm: "StateMachine", event: Event) -> None:
     sm.phase = OfficePhase.ENDED
     sm.boss_state = BossState.IDLE
     sm.boss_current_task = None
+    sm.turn_active = False
 
 
 def _handle_background_task_notification(sm: "StateMachine", event: Event) -> None:
@@ -456,6 +460,7 @@ def _handle_teammate_idle(sm: "StateMachine", event: Event) -> None:
     """Handle TEAMMATE_IDLE: set teammate boss state to idle."""
     sm.boss_state = BossState.IDLE
     sm.boss_bubble = None
+    sm.turn_active = False
 
 
 # ---------------------------------------------------------------------------
@@ -529,6 +534,11 @@ class StateMachine:
     token_tracker: TokenTracker = field(default_factory=TokenTracker)
     tool_uses_since_compaction: int = 0
     print_report: bool = False
+    # True from the moment a user prompt arrives until the turn completes
+    # (STOP) or the session ends. Lets the Command Center treat the brief
+    # idle *between* tool calls as "still working" instead of flickering the
+    # terminal into the "done" zone and back every tool cycle.
+    turn_active: bool = False
     last_user_prompt: str | None = None
     background_tasks: list[BackgroundTask] = field(default_factory=_empty_background_tasks)
     conversation: list[ConversationEntry] = field(default_factory=_empty_conversation)

--- a/backend/app/core/whiteboard_tracker.py
+++ b/backend/app/core/whiteboard_tracker.py
@@ -221,7 +221,10 @@ class WhiteboardTracker:
         if existing_task:
             existing_task.status = status
             existing_task.summary = summary
-            existing_task.completed_at = datetime.now(UTC).isoformat()
+            # Only stamp completed_at when the task reaches a terminal status.
+            # A "running" update must not mark an active background task finished.
+            if status != "running":
+                existing_task.completed_at = datetime.now(UTC).isoformat()
         else:
             new_task = BackgroundTask(
                 task_id=task_id,

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -33,6 +33,10 @@ _SERVE_STATIC = os.environ.get("SERVE_STATIC", "").lower() in ("1", "true", "yes
 
 _LOCALHOST_HOSTS = frozenset({"127.0.0.1", "::1", "localhost", "testclient"})
 
+# Upper bound on concurrent /ws/overview (Command Center) watchers. Each one
+# amplifies the per-event overview rebuild cost, so refuse new ones past this.
+_MAX_OVERVIEW_CONNECTIONS = 16
+
 
 class LocalhostOnlyMiddleware(BaseHTTPMiddleware):
     """Reject HTTP requests from non-localhost origins.
@@ -257,16 +261,25 @@ async def websocket_overview(websocket: WebSocket) -> None:
     id, accept, find no state, and silently idle).
     """
     from app.api.websocket import validate_websocket_origin
-    from app.core.room_orchestrator import build_overview
 
     if not validate_websocket_origin(websocket):
         await websocket.close(code=4003, reason="Origin not allowed")
         return
 
+    # Cap concurrent overview watchers: each connection amplifies the per-event
+    # overview rebuild cost, so refuse beyond the limit instead of letting it
+    # grow unbounded.
+    if len(manager.overview_connections) >= _MAX_OVERVIEW_CONNECTIONS:
+        await websocket.close(code=4013, reason="Too many overview connections")
+        return
+
     await manager.connect_overview(websocket)
     try:
-        # Send the current overview snapshot on connect.
-        overview = build_overview(event_processor.sessions)
+        # Send the current overview snapshot on connect. Built under the same
+        # ``_sessions_lock`` used by the per-event broadcast so it reads a
+        # consistent registry snapshot and can't race a concurrent event handler
+        # resizing ``sessions`` mid-iteration.
+        overview = await event_processor.build_overview_snapshot()
         await websocket.send_json(
             {
                 "type": "state_update",

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -245,6 +245,43 @@ async def get_status() -> dict[str, bool | str | None]:
     }
 
 
+@app.websocket("/ws/overview")
+async def websocket_overview(websocket: WebSocket) -> None:
+    """Overview WebSocket: boss status of every live session (Command Center).
+
+    Declared BEFORE ``/ws/{session_id}`` so the single-segment path ``/ws/overview``
+    isn't captured by the session route (which would treat "overview" as a session
+    id, accept, find no state, and silently idle).
+    """
+    from app.api.websocket import validate_websocket_origin
+    from app.core.room_orchestrator import build_overview
+
+    if not validate_websocket_origin(websocket):
+        await websocket.close(code=4003, reason="Origin not allowed")
+        return
+
+    await manager.connect_overview(websocket)
+    try:
+        # Send the current overview snapshot on connect.
+        overview = build_overview(event_processor.sessions)
+        await websocket.send_json(
+            {
+                "type": "state_update",
+                "timestamp": overview.last_updated.isoformat(),
+                "state": overview.model_dump(mode="json", by_alias=True),
+            }
+        )
+        # Keep alive -- discard incoming messages
+        while True:
+            await websocket.receive_text()
+    except WebSocketDisconnect:
+        pass
+    except Exception:
+        logger.warning("Overview WebSocket error", exc_info=True)
+    finally:
+        await manager.disconnect_overview(websocket)
+
+
 @app.websocket("/ws/{session_id}")
 async def websocket_endpoint(websocket: WebSocket, session_id: str) -> None:
     from app.api.websocket import validate_session_id, validate_websocket_origin

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -62,15 +62,18 @@ _NO_AUTH_PATHS = frozenset({"/health", "/docs", "/redoc"})
 
 
 def _is_state_changing(path: str, method: str) -> bool:
-    """Return True if the request targets a state-changing endpoint."""
+    """Return True if the request targets a destructive global endpoint.
+
+    When no explicit ``CLAUDE_OFFICE_API_KEY`` is configured, only the
+    destructive *global* operations (clearing all sessions, running a
+    simulation) require the auto-generated token.  Per-session mutations
+    (delete, label, focus) and preferences writes remain open in the default
+    configuration; they are still fully gated whenever an explicit key is set
+    (handled by ``settings.has_explicit_key`` in the middleware).
+    """
     prefix = settings.API_V1_STR + "/sessions"
-    prefs_prefix = settings.API_V1_STR + "/preferences"
-    return (
-        (path == prefix and method == "DELETE")
-        or (path == f"{prefix}/simulate" and method == "POST")
-        or (path.startswith(f"{prefix}/") and path.endswith("/focus") and method == "POST")
-        or (path.startswith(f"{prefix}/") and method in ("DELETE", "PATCH"))
-        or (path.startswith(f"{prefs_prefix}/") and method in ("PUT", "DELETE"))
+    return (path == prefix and method == "DELETE") or (
+        path == f"{prefix}/simulate" and method == "POST"
     )
 
 

--- a/backend/app/models/overview.py
+++ b/backend/app/models/overview.py
@@ -10,9 +10,9 @@ equal "peer".
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Literal
+from typing import Literal, cast
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 from pydantic.alias_generators import to_camel
 
 from app.models.agents import BossState
@@ -48,5 +48,5 @@ class OverviewState(BaseModel):
 
     model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
 
-    entries: list[OverviewEntry] = []
+    entries: list[OverviewEntry] = Field(default_factory=lambda: cast(list[OverviewEntry], []))
     last_updated: datetime

--- a/backend/app/models/overview.py
+++ b/backend/app/models/overview.py
@@ -1,0 +1,52 @@
+"""Cross-session overview models for the Command Center view.
+
+The Command Center gathers the boss (main agent) of every live session into a
+single compact payload so the user can see, at a glance, which terminals are
+working, which need attention, and which are done.  Unlike the room-level merge,
+there is no lead/teammate hierarchy and no desk layout — every session is an
+equal "peer".
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict
+from pydantic.alias_generators import to_camel
+
+from app.models.agents import BossState
+
+__all__ = [
+    "OverviewBucket",
+    "OverviewEntry",
+    "OverviewState",
+]
+
+# Status buckets used to place a peer into a zone on the Command Center canvas.
+# The "ended" bucket is applied frontend-side from the session list, so it is
+# not part of the live backend payload.
+OverviewBucket = Literal["needs_you", "working", "done"]
+
+
+class OverviewEntry(BaseModel):
+    """A single session's boss snapshot for the Command Center."""
+
+    model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
+
+    session_id: str
+    bucket: OverviewBucket
+    state: BossState  # raw boss state, for the peer tooltip
+    current_task: str | None = None
+    todo_done: int = 0
+    todo_total: int = 0
+    subagent_count: int = 0
+
+
+class OverviewState(BaseModel):
+    """The full cross-session overview broadcast over ``/ws/overview``."""
+
+    model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
+
+    entries: list[OverviewEntry] = []
+    last_updated: datetime

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "claude-office-visualizer"
-version = "0.19.0"
+version = "0.20.0"
 description = "Real-time pixel art visualization of Claude Code operations"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/backend/tests/test_room_orchestrator.py
+++ b/backend/tests/test_room_orchestrator.py
@@ -1,9 +1,10 @@
 # backend/tests/test_room_orchestrator.py
 """Tests for RoomOrchestrator: session merging, character types, kanban aggregation."""
 
-from app.core.room_orchestrator import RoomOrchestrator
+from app.core.room_orchestrator import RoomOrchestrator, build_overview
 from app.core.state_machine import StateMachine
-from app.models.agents import AgentState, BossState
+from app.models.agents import Agent, AgentState, BossState
+from app.models.common import TodoItem, TodoStatus
 from app.models.events import Event, EventData, EventType
 
 
@@ -171,3 +172,52 @@ class TestSessionLifecycle:
         state = orch.merge()
         assert state is not None
         assert state.boss.state == BossState.WORKING
+
+
+class TestBuildOverview:
+    def test_empty(self) -> None:
+        ov = build_overview({})
+        assert ov.entries == []
+
+    def test_one_peer_per_session(self) -> None:
+        a, b = _make_sm(), _make_sm()
+        a.boss_state = BossState.WORKING
+        b.boss_state = BossState.IDLE
+        ov = build_overview({"s-a": a, "s-b": b})
+        by_id = {e.session_id: e for e in ov.entries}
+        assert set(by_id) == {"s-a", "s-b"}
+
+    def test_bucket_mapping(self) -> None:
+        cases = {
+            BossState.WAITING_PERMISSION: "needs_you",
+            BossState.PHONE_RINGING: "needs_you",
+            BossState.WORKING: "working",
+            BossState.DELEGATING: "working",
+            BossState.REVIEWING: "working",
+            BossState.IDLE: "done",
+            BossState.COMPLETING: "done",
+        }
+        for state, expected in cases.items():
+            sm = _make_sm()
+            sm.boss_state = state
+            ov = build_overview({"s": sm})
+            assert ov.entries[0].bucket == expected
+            assert ov.entries[0].state == state
+
+    def test_todo_counts_and_subagents(self) -> None:
+        sm = _make_sm()
+        sm.boss_state = BossState.WORKING
+        sm.boss_current_task = "refactor auth"
+        sm.todos = [
+            TodoItem(content="a", status=TodoStatus.COMPLETED),
+            TodoItem(content="b", status=TodoStatus.IN_PROGRESS),
+            TodoItem(content="c", status=TodoStatus.PENDING),
+        ]
+        sm.agents = {
+            "x": Agent(id="x", color="#fff", number=0, state=AgentState.WORKING),
+            "y": Agent(id="y", color="#fff", number=1, state=AgentState.WORKING),
+        }
+        entry = build_overview({"s": sm}).entries[0]
+        assert entry.current_task == "refactor auth"
+        assert (entry.todo_done, entry.todo_total) == (1, 3)
+        assert entry.subagent_count == 2

--- a/backend/tests/test_room_orchestrator.py
+++ b/backend/tests/test_room_orchestrator.py
@@ -204,6 +204,37 @@ class TestBuildOverview:
             assert ov.entries[0].bucket == expected
             assert ov.entries[0].state == state
 
+    def test_idle_mid_turn_stays_working(self) -> None:
+        # The boss drops to IDLE between tool calls; while the turn is still
+        # running the terminal must not flicker into the "done" zone.
+        sm = _make_sm()
+        sm.boss_state = BossState.IDLE
+        sm.turn_active = True
+        assert build_overview({"s": sm}).entries[0].bucket == "working"
+
+    def test_idle_with_live_subagents_stays_working(self) -> None:
+        # A subagent stop flips the boss to IDLE, but if children are still
+        # present the parent counts as working.
+        sm = _make_sm()
+        sm.boss_state = BossState.IDLE
+        sm.turn_active = False
+        sm.agents = {"x": Agent(id="x", color="#fff", number=0, state=AgentState.WORKING)}
+        assert build_overview({"s": sm}).entries[0].bucket == "working"
+
+    def test_idle_after_turn_is_done(self) -> None:
+        # No active turn and no subagents -> genuinely idle/waiting.
+        sm = _make_sm()
+        sm.boss_state = BossState.IDLE
+        sm.turn_active = False
+        assert build_overview({"s": sm}).entries[0].bucket == "done"
+
+    def test_needs_you_wins_over_turn_active(self) -> None:
+        # Blocked-on-user states must surface even mid-turn.
+        sm = _make_sm()
+        sm.boss_state = BossState.WAITING_PERMISSION
+        sm.turn_active = True
+        assert build_overview({"s": sm}).entries[0].bucket == "needs_you"
+
     def test_todo_counts_and_subagents(self) -> None:
         sm = _make_sm()
         sm.boss_state = BossState.WORKING

--- a/backend/tests/test_websocket_room.py
+++ b/backend/tests/test_websocket_room.py
@@ -43,3 +43,90 @@ class TestRoomConnections:
         mgr = ConnectionManager()
         # Should not raise
         await mgr.broadcast_room({"type": "test"}, "room-with-no-subs")
+
+
+class TestOverviewConnections:
+    @pytest.mark.asyncio
+    async def test_connect_overview_registers_connection(self) -> None:
+        mgr = ConnectionManager()
+        ws = AsyncMock()
+        ws.client_state = MagicMock()
+        await mgr.connect_overview(ws)
+        assert ws in mgr.overview_connections
+
+    @pytest.mark.asyncio
+    async def test_disconnect_overview_removes_connection(self) -> None:
+        mgr = ConnectionManager()
+        ws = AsyncMock()
+        ws.client_state = MagicMock()
+        await mgr.connect_overview(ws)
+        await mgr.disconnect_overview(ws)
+        assert ws not in mgr.overview_connections
+
+    @pytest.mark.asyncio
+    async def test_broadcast_overview_sends_to_connections(self) -> None:
+        mgr = ConnectionManager()
+        ws = AsyncMock()
+        from starlette.websockets import WebSocketState
+
+        ws.client_state = WebSocketState.CONNECTED
+        await mgr.connect_overview(ws)
+        await mgr.broadcast_overview({"type": "test"})
+        ws.send_json.assert_called_once_with({"type": "test"})
+
+    @pytest.mark.asyncio
+    async def test_broadcast_overview_noop_when_no_connections(self) -> None:
+        mgr = ConnectionManager()
+        # Should not raise
+        await mgr.broadcast_overview({"type": "test"})
+
+
+class TestOverviewRouteOrder:
+    def test_overview_route_registered_before_session_route(self) -> None:
+        """`/ws/overview` is a single segment and would be captured by the
+        `/ws/{session_id}` route unless declared first — which silently breaks
+        the Command Center feed. Guard the registration order."""
+        from app.main import app
+
+        paths = [getattr(r, "path", None) for r in app.routes]
+        assert "/ws/overview" in paths
+        assert "/ws/{session_id}" in paths
+        assert paths.index("/ws/overview") < paths.index("/ws/{session_id}")
+
+
+class TestBroadcastOverviewState:
+    @pytest.mark.asyncio
+    async def test_skips_build_when_no_watchers(self) -> None:
+        """The per-event hook must be cheap when nobody is watching."""
+        from app.api import websocket as ws_module
+        from app.core.broadcast_service import broadcast_overview_state
+
+        # No overview connections on the live manager -> no-op, no build.
+        ws_module.manager.overview_connections.clear()
+        await broadcast_overview_state({})  # must not raise
+
+    @pytest.mark.asyncio
+    async def test_broadcasts_entries_to_watcher(self) -> None:
+        from starlette.websockets import WebSocketState
+
+        from app.api import websocket as ws_module
+        from app.core.broadcast_service import broadcast_overview_state
+        from app.core.state_machine import StateMachine
+        from app.models.agents import BossState
+
+        ws = AsyncMock()
+        ws.client_state = WebSocketState.CONNECTED
+        await ws_module.manager.connect_overview(ws)
+        try:
+            sm = StateMachine()
+            sm.boss_state = BossState.WAITING_PERMISSION
+            await broadcast_overview_state({"sess-1": sm})
+
+            ws.send_json.assert_called_once()
+            payload = ws.send_json.call_args[0][0]
+            assert payload["type"] == "state_update"
+            entries = payload["state"]["entries"]
+            assert entries[0]["sessionId"] == "sess-1"
+            assert entries[0]["bucket"] == "needs_you"
+        finally:
+            await ws_module.manager.disconnect_overview(ws)

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -80,7 +80,7 @@ wheels = [
 
 [[package]]
 name = "claude-office-visualizer"
-version = "0.19.0"
+version = "0.20.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "private": true,
   "scripts": {
     "dev": "next dev --turbo",

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -79,6 +79,17 @@ body {
 }
 
 @layer utilities {
+  /* react-zoom-pan-pinch sizes its wrapper/content to fit-content by default,
+     so a wide canvas column makes the content taller than its container and the
+     bottom gets clipped by overflow-hidden. Force them to fill the container so
+     object-fit: contain can letterbox the canvas and keep every edge visible
+     (otherwise the Command Center's wide canvas crops the bottom of the room). */
+  .react-transform-wrapper,
+  .react-transform-component {
+    width: 100% !important;
+    height: 100% !important;
+  }
+
   /* PixiJS Canvas Scaling — anchored to top-left to prevent drift from
      flex centering recalculations during frequent WebSocket re-renders */
   .pixi-canvas-container canvas {

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -45,6 +45,7 @@ import { Breadcrumb } from "@/components/navigation/Breadcrumb";
 import { ViewTransition } from "@/components/navigation/ViewTransition";
 import { BuildingView } from "@/components/views/BuildingView";
 import { FloorView } from "@/components/views/FloorView";
+import { CommandCenterView } from "@/components/command/CommandCenterView";
 import { TourOverlay } from "@/components/tour/TourOverlay";
 import CommandBar from "@/components/attention/CommandBar";
 import AttentionToasts from "@/components/attention/AttentionToasts";
@@ -151,6 +152,11 @@ export default function V2TestPage(): React.ReactNode {
 
   // Navigation store
   const view = useNavigationStore((s) => s.view);
+
+  // Active session count gates the Command Center entry point (>= 2).
+  const activeSessionCount = sessions.filter(
+    (s) => s.status === "active",
+  ).length;
 
   // ------------------------------------------------------------------
   // Floor config + tour initialization
@@ -395,7 +401,7 @@ export default function V2TestPage(): React.ReactNode {
             {!isMobile && t("app.title")}
             {!isMobile && (
               <span className="text-xs font-mono font-normal px-2 py-0.5 bg-slate-800 rounded text-slate-400 border border-slate-700">
-                v0.19.0
+                v0.20.0
               </span>
             )}
           </h1>
@@ -414,6 +420,7 @@ export default function V2TestPage(): React.ReactNode {
             isConnected={isConnected}
             debugMode={debugMode}
             aiSummaryEnabled={aiSummaryEnabled}
+            activeSessionCount={activeSessionCount}
             onSimulate={handleSimulate}
             onReset={handleReset}
             onClearDB={() => setIsClearModalOpen(true)}
@@ -492,6 +499,22 @@ export default function V2TestPage(): React.ReactNode {
 
           <RightSidebar />
         </div>
+      ) : view === "command" ? (
+        /* ----------------------------------------------------------------
+            Command Center (cross-terminal overview)
+        ---------------------------------------------------------------- */
+        <CommandCenterView
+          sessions={sessions}
+          sessionsLoading={sessionsLoading}
+          sessionId={sessionId}
+          isCollapsed={leftSidebarCollapsed}
+          onToggleCollapsed={() =>
+            setLeftSidebarCollapsed(!leftSidebarCollapsed)
+          }
+          onSessionSelect={handleSessionSelect}
+          onDeleteSession={setSessionPendingDelete}
+          onRenameSession={handleRenameSession}
+        />
       ) : (
         /* ----------------------------------------------------------------
             Building / Floor View (animated transitions)

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -29,7 +29,7 @@ import { useNavigationStore } from "@/stores/navigationStore";
 import { useTourStore } from "@/stores/tourStore";
 import { useShallow } from "zustand/react/shallow";
 import { setApiKey, apiFetch } from "@/utils/api";
-import { Menu, X } from "lucide-react";
+import { Menu, X, Map } from "lucide-react";
 import { SessionSidebar } from "@/components/layout/SessionSidebar";
 import { MobileDrawer } from "@/components/layout/MobileDrawer";
 import { MobileAgentActivity } from "@/components/layout/MobileAgentActivity";
@@ -152,6 +152,17 @@ export default function V2TestPage(): React.ReactNode {
 
   // Navigation store
   const view = useNavigationStore((s) => s.view);
+  const buildingConfig = useNavigationStore((s) => s.buildingConfig);
+
+  // Onboarding tour now lives in the Help modal (rarely used).
+  const startTour = useTourStore((s) => s.startTour);
+  const handleStartTour = (): void => {
+    const hasBuildingConfig =
+      buildingConfig !== null && (buildingConfig.floors.length ?? 0) > 0;
+    const mode = view !== "single" && hasBuildingConfig ? "building" : "single";
+    startTour(mode);
+    setIsHelpModalOpen(false);
+  };
 
   // Active session count gates the Command Center entry point (>= 2).
   const activeSessionCount = sessions.filter(
@@ -299,12 +310,21 @@ export default function V2TestPage(): React.ReactNode {
         onClose={() => setIsHelpModalOpen(false)}
         title={t("modal.keyboardShortcuts")}
         footer={
-          <button
-            onClick={() => setIsHelpModalOpen(false)}
-            className="px-4 py-2 bg-slate-700 hover:bg-slate-600 text-white text-sm font-bold rounded-lg transition-colors"
-          >
-            {t("modal.close")}
-          </button>
+          <>
+            <button
+              onClick={handleStartTour}
+              className="flex items-center gap-2 px-4 py-2 bg-orange-500/10 hover:bg-orange-500/20 text-orange-400 border border-orange-500/30 text-sm font-bold rounded-lg transition-colors"
+            >
+              <Map size={16} />
+              {t("help.tour")}
+            </button>
+            <button
+              onClick={() => setIsHelpModalOpen(false)}
+              className="px-4 py-2 bg-slate-700 hover:bg-slate-600 text-white text-sm font-bold rounded-lg transition-colors"
+            >
+              {t("modal.close")}
+            </button>
+          </>
         }
       >
         <div className="space-y-3 font-mono text-sm">
@@ -408,11 +428,6 @@ export default function V2TestPage(): React.ReactNode {
 
           {/* Breadcrumb — only when in building/floor view */}
           {!isMobile && <Breadcrumb />}
-        </div>
-
-        {/* Centered status toast */}
-        <div className="absolute left-1/3 -translate-x-1/2 flex items-center pointer-events-none">
-          <StatusToast message={statusMessage} />
         </div>
 
         {!isMobile && (
@@ -550,6 +565,13 @@ export default function V2TestPage(): React.ReactNode {
           Tour Overlay
       ---------------------------------------------------------------- */}
       <TourOverlay />
+
+      {/* ----------------------------------------------------------------
+          Status Toast — pinned bottom-center so it never covers the header
+      ---------------------------------------------------------------- */}
+      <div className="fixed bottom-6 left-1/2 -translate-x-1/2 z-50 flex items-center pointer-events-none">
+        <StatusToast message={statusMessage} />
+      </div>
     </main>
   );
 }

--- a/frontend/src/components/command/CommandCenterBackground.tsx
+++ b/frontend/src/components/command/CommandCenterBackground.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import { type ReactNode, useMemo, useCallback } from "react";
+import { Graphics, Texture } from "pixi.js";
+import { CANVAS_WIDTH, CANVAS_HEIGHT } from "@/constants/canvas";
+import { TOP_WALL_H } from "./layout";
+
+// Mirrors the office theme (components/game/OfficeBackground.tsx).
+const FLOOR_COLOR = 0x2a2a2a;
+const WALL_COLOR = 0x3d3d3d;
+const WALL_TRIM_COLOR = 0x4a4a4a;
+const WALL_TRIM_H = 10;
+const FLOOR_TILE_SIZE = 100;
+
+const TILE_TINT_LIGHT = 0xffffff;
+const TILE_TINT_DARK = 0xd8d8d8;
+
+interface TileData {
+  x: number;
+  y: number;
+  rotation: number;
+  tint: number;
+}
+
+interface CommandCenterBackgroundProps {
+  floorTileTexture?: Texture | null;
+}
+
+/**
+ * Office-matched backdrop: a decorated top wall over a checkerboard tiled floor,
+ * using the same palette and tile texture as the main office.
+ */
+export function CommandCenterBackground({
+  floorTileTexture,
+}: CommandCenterBackgroundProps): ReactNode {
+  const tiles = useMemo(() => {
+    const result: TileData[] = [];
+    for (let y = TOP_WALL_H; y < CANVAS_HEIGHT; y += FLOOR_TILE_SIZE) {
+      const rowIndex = Math.floor((y - TOP_WALL_H) / FLOOR_TILE_SIZE);
+      for (let x = 0; x < CANVAS_WIDTH; x += FLOOR_TILE_SIZE) {
+        const colIndex = Math.floor(x / FLOOR_TILE_SIZE);
+        const isAlternate = (rowIndex + colIndex) % 2 === 1;
+        result.push({
+          x: x + FLOOR_TILE_SIZE / 2,
+          y: y + FLOOR_TILE_SIZE / 2,
+          rotation: isAlternate ? Math.PI / 2 : 0,
+          tint: isAlternate ? TILE_TINT_DARK : TILE_TINT_LIGHT,
+        });
+      }
+    }
+    return result;
+  }, []);
+
+  const drawWallsAndFloor = useCallback((g: Graphics) => {
+    g.clear();
+    // Floor base (fallback behind tiles).
+    g.rect(0, TOP_WALL_H, CANVAS_WIDTH, CANVAS_HEIGHT - TOP_WALL_H);
+    g.fill(FLOOR_COLOR);
+    // Top wall.
+    g.rect(0, 0, CANVAS_WIDTH, TOP_WALL_H);
+    g.fill(WALL_COLOR);
+    // Wall base trim.
+    g.rect(0, TOP_WALL_H - WALL_TRIM_H, CANVAS_WIDTH, WALL_TRIM_H);
+    g.fill(WALL_TRIM_COLOR);
+  }, []);
+
+  return (
+    <>
+      <pixiGraphics draw={drawWallsAndFloor} />
+      {floorTileTexture &&
+        tiles.map((tile, index) => (
+          <pixiSprite
+            key={index}
+            texture={floorTileTexture}
+            x={tile.x}
+            y={tile.y}
+            anchor={0.5}
+            rotation={tile.rotation}
+            tint={tile.tint}
+          />
+        ))}
+    </>
+  );
+}

--- a/frontend/src/components/command/CommandCenterBoard.tsx
+++ b/frontend/src/components/command/CommandCenterBoard.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, type ReactNode } from "react";
 import { Graphics } from "pixi.js";
+import { useTranslation } from "@/hooks/useTranslation";
 import { ZONE_BY_KEY, type ZoneKey } from "./layout";
 import type { CommandSummary } from "./useCommandCenterPeers";
 
@@ -22,6 +23,7 @@ export function CommandCenterBoard({
   counts,
   summary,
 }: CommandCenterBoardProps): ReactNode {
+  const { t } = useTranslation();
   const drawBoard = useCallback((g: Graphics) => {
     g.clear();
     // Frame.
@@ -37,7 +39,10 @@ export function CommandCenterBoard({
     g.fill({ color: 0x475569 });
   }, []);
 
-  const todoRatio = summary.todoTotal > 0 ? summary.todoDone / summary.todoTotal : 0;
+  const todoRatio =
+    summary.todoTotal > 0
+      ? Math.max(0, Math.min(1, summary.todoDone / summary.todoTotal))
+      : 0;
   const drawTodoBar = useCallback(
     (g: Graphics) => {
       g.clear();
@@ -64,7 +69,7 @@ export function CommandCenterBoard({
       {/* Title */}
       <pixiContainer x={0} y={-H / 2 + 16} scale={0.5}>
         <pixiText
-          text={`\u{1F4CB} ALL SESSIONS`}
+          text={`\u{1F4CB} ${t("commandCenter.board.allSessions")}`}
           anchor={{ x: 0.5, y: 0.5 }}
           resolution={2}
           style={{
@@ -79,7 +84,7 @@ export function CommandCenterBoard({
       {/* Terminals + employees */}
       <pixiContainer x={left} y={-H / 2 + 38} scale={0.5}>
         <pixiText
-          text={`Terminals: ${summary.terminals}    Employees: ${summary.subagents}`}
+          text={`${t("commandCenter.board.terminals")}: ${summary.terminals}    ${t("commandCenter.board.employees")}: ${summary.subagents}`}
           anchor={{ x: 0, y: 0.5 }}
           resolution={2}
           style={{ fontFamily: "monospace", fontSize: 22, fill: 0x334155 }}
@@ -92,7 +97,12 @@ export function CommandCenterBoard({
           text={`⚠ ${counts.needs_you ?? 0}`}
           anchor={{ x: 0, y: 0.5 }}
           resolution={2}
-          style={{ fontFamily: "monospace", fontSize: 22, fill: ZONE_BY_KEY.needs_you.color, fontWeight: "bold" }}
+          style={{
+            fontFamily: "monospace",
+            fontSize: 22,
+            fill: ZONE_BY_KEY.needs_you.color,
+            fontWeight: "bold",
+          }}
         />
       </pixiContainer>
       <pixiContainer x={left + 56} y={-H / 2 + 58} scale={0.5}>
@@ -100,7 +110,12 @@ export function CommandCenterBoard({
           text={`\u{1F7E2} ${counts.working ?? 0}`}
           anchor={{ x: 0, y: 0.5 }}
           resolution={2}
-          style={{ fontFamily: "monospace", fontSize: 22, fill: ZONE_BY_KEY.working.color, fontWeight: "bold" }}
+          style={{
+            fontFamily: "monospace",
+            fontSize: 22,
+            fill: ZONE_BY_KEY.working.color,
+            fontWeight: "bold",
+          }}
         />
       </pixiContainer>
       <pixiContainer x={left + 112} y={-H / 2 + 58} scale={0.5}>
@@ -108,14 +123,19 @@ export function CommandCenterBoard({
           text={`✅ ${counts.done ?? 0}`}
           anchor={{ x: 0, y: 0.5 }}
           resolution={2}
-          style={{ fontFamily: "monospace", fontSize: 22, fill: ZONE_BY_KEY.done.color, fontWeight: "bold" }}
+          style={{
+            fontFamily: "monospace",
+            fontSize: 22,
+            fill: ZONE_BY_KEY.done.color,
+            fontWeight: "bold",
+          }}
         />
       </pixiContainer>
 
       {/* Aggregate todo progress */}
       <pixiContainer x={left} y={-H / 2 + 76} scale={0.5}>
         <pixiText
-          text={`Todos ${summary.todoDone}/${summary.todoTotal}`}
+          text={`${t("commandCenter.board.todos")} ${summary.todoDone}/${summary.todoTotal}`}
           anchor={{ x: 0, y: 0.5 }}
           resolution={2}
           style={{ fontFamily: "monospace", fontSize: 20, fill: 0x334155 }}

--- a/frontend/src/components/command/CommandCenterBoard.tsx
+++ b/frontend/src/components/command/CommandCenterBoard.tsx
@@ -1,0 +1,129 @@
+"use client";
+
+import { useCallback, type ReactNode } from "react";
+import { Graphics } from "pixi.js";
+import { ZONE_BY_KEY, type ZoneKey } from "./layout";
+import type { CommandSummary } from "./useCommandCenterPeers";
+
+const W = 252;
+const H = 104;
+
+interface CommandCenterBoardProps {
+  counts: Record<ZoneKey, number>;
+  summary: CommandSummary;
+}
+
+/**
+ * A whiteboard on the top wall (like the office whiteboard) showing the COMBINED
+ * stats of every session: terminal count, per-status counts, total employees
+ * (subagents), and aggregate todo progress.
+ */
+export function CommandCenterBoard({
+  counts,
+  summary,
+}: CommandCenterBoardProps): ReactNode {
+  const drawBoard = useCallback((g: Graphics) => {
+    g.clear();
+    // Frame.
+    g.roundRect(-W / 2 - 5, -H / 2 - 5, W + 10, H + 10, 6);
+    g.fill({ color: 0x1f2937 });
+    // Whiteboard surface.
+    g.roundRect(-W / 2, -H / 2, W, H, 4);
+    g.fill({ color: 0xf1f5f9 });
+    g.roundRect(-W / 2, -H / 2, W, H, 4);
+    g.stroke({ color: 0xcbd5e1, width: 2 });
+    // Marker tray.
+    g.roundRect(-W / 2 + 14, H / 2 + 2, 56, 5, 2);
+    g.fill({ color: 0x475569 });
+  }, []);
+
+  const todoRatio = summary.todoTotal > 0 ? summary.todoDone / summary.todoTotal : 0;
+  const drawTodoBar = useCallback(
+    (g: Graphics) => {
+      g.clear();
+      const w = 150;
+      const h = 8;
+      g.roundRect(0, 0, w, h, 4);
+      g.fill({ color: 0xe2e8f0 });
+      g.roundRect(0, 0, w, h, 4);
+      g.stroke({ color: 0xcbd5e1, width: 1 });
+      if (todoRatio > 0) {
+        g.roundRect(0, 0, Math.max(4, w * todoRatio), h, 4);
+        g.fill({ color: 0x22c55e });
+      }
+    },
+    [todoRatio],
+  );
+
+  const left = -W / 2 + 16;
+
+  return (
+    <pixiContainer>
+      <pixiGraphics draw={drawBoard} />
+
+      {/* Title */}
+      <pixiContainer x={0} y={-H / 2 + 16} scale={0.5}>
+        <pixiText
+          text={`\u{1F4CB} ALL SESSIONS`}
+          anchor={{ x: 0.5, y: 0.5 }}
+          resolution={2}
+          style={{
+            fontFamily: "monospace",
+            fontSize: 26,
+            fill: 0x0f172a,
+            fontWeight: "bold",
+          }}
+        />
+      </pixiContainer>
+
+      {/* Terminals + employees */}
+      <pixiContainer x={left} y={-H / 2 + 38} scale={0.5}>
+        <pixiText
+          text={`Terminals: ${summary.terminals}    Employees: ${summary.subagents}`}
+          anchor={{ x: 0, y: 0.5 }}
+          resolution={2}
+          style={{ fontFamily: "monospace", fontSize: 22, fill: 0x334155 }}
+        />
+      </pixiContainer>
+
+      {/* Per-status counts in zone colors */}
+      <pixiContainer x={left} y={-H / 2 + 58} scale={0.5}>
+        <pixiText
+          text={`⚠ ${counts.needs_you ?? 0}`}
+          anchor={{ x: 0, y: 0.5 }}
+          resolution={2}
+          style={{ fontFamily: "monospace", fontSize: 22, fill: ZONE_BY_KEY.needs_you.color, fontWeight: "bold" }}
+        />
+      </pixiContainer>
+      <pixiContainer x={left + 56} y={-H / 2 + 58} scale={0.5}>
+        <pixiText
+          text={`\u{1F7E2} ${counts.working ?? 0}`}
+          anchor={{ x: 0, y: 0.5 }}
+          resolution={2}
+          style={{ fontFamily: "monospace", fontSize: 22, fill: ZONE_BY_KEY.working.color, fontWeight: "bold" }}
+        />
+      </pixiContainer>
+      <pixiContainer x={left + 112} y={-H / 2 + 58} scale={0.5}>
+        <pixiText
+          text={`✅ ${counts.done ?? 0}`}
+          anchor={{ x: 0, y: 0.5 }}
+          resolution={2}
+          style={{ fontFamily: "monospace", fontSize: 22, fill: ZONE_BY_KEY.done.color, fontWeight: "bold" }}
+        />
+      </pixiContainer>
+
+      {/* Aggregate todo progress */}
+      <pixiContainer x={left} y={-H / 2 + 76} scale={0.5}>
+        <pixiText
+          text={`Todos ${summary.todoDone}/${summary.todoTotal}`}
+          anchor={{ x: 0, y: 0.5 }}
+          resolution={2}
+          style={{ fontFamily: "monospace", fontSize: 20, fill: 0x334155 }}
+        />
+      </pixiContainer>
+      <pixiContainer x={left + 44} y={-H / 2 + 80}>
+        <pixiGraphics draw={drawTodoBar} />
+      </pixiContainer>
+    </pixiContainer>
+  );
+}

--- a/frontend/src/components/command/CommandCenterCanvas.tsx
+++ b/frontend/src/components/command/CommandCenterCanvas.tsx
@@ -86,20 +86,28 @@ export function CommandCenterCanvas({
 
   return (
     <div className="w-full h-full overflow-hidden relative">
-      {/* Same controls/feel as the floor views (shared ZoomControls, pinch,
-          resize-reset), but the Command Center area is taller than a single
-          office, so allow zooming out below 1:1 to reveal the bottom edge —
-          centerZoomedOut keeps the shrunk board centred in the viewport. */}
+      {/* Identical zoom behaviour to the floor views (OfficeGame): the whole
+          board fits at 1:1 — the global .react-transform-* fill rule lets
+          object-fit: contain letterbox it so no edge is clipped. */}
       <TransformWrapper
         ref={transformRef}
         initialScale={1}
-        minScale={0.5}
+        minScale={1}
         maxScale={3}
-        centerZoomedOut={true}
+        centerZoomedOut={false}
         limitToBounds={false}
         wheel={{ step: 0.1 }}
         pinch={{ step: 5 }}
         doubleClick={{ mode: "reset" }}
+        onTransform={(ref, state) => {
+          // Auto-reset pan offset when zooming back out to 1:1
+          if (
+            state.scale <= 1 &&
+            (state.positionX !== 0 || state.positionY !== 0)
+          ) {
+            ref.resetTransform(0);
+          }
+        }}
       >
         <ZoomControls />
         <TransformComponent

--- a/frontend/src/components/command/CommandCenterCanvas.tsx
+++ b/frontend/src/components/command/CommandCenterCanvas.tsx
@@ -21,6 +21,7 @@ import {
 } from "@/systems/commandCenterMotion";
 import { LoadingScreen } from "../game/LoadingScreen";
 import { WallClock } from "../game/WallClock";
+import { ZoomControls } from "../game/ZoomControls";
 import { CommandCenterBackground } from "./CommandCenterBackground";
 import { CommandCenterZones } from "./CommandCenterZones";
 import { CommandCenterDecor } from "./CommandCenterDecor";
@@ -75,18 +76,37 @@ export function CommandCenterCanvas({
     useExitStore.getState().registerEnded(exiting, performance.now());
   }, [peers]);
 
+  // Reset pan/zoom only on actual window resize — mirrors OfficeGame so the
+  // Command Center camera behaves identically to the floor views.
+  useEffect(() => {
+    const handleResize = () => transformRef.current?.resetTransform(0);
+    window.addEventListener("resize", handleResize);
+    return () => window.removeEventListener("resize", handleResize);
+  }, []);
+
   return (
     <div className="w-full h-full overflow-hidden relative">
       <TransformWrapper
         ref={transformRef}
         initialScale={1}
-        minScale={0.5}
+        minScale={1}
         maxScale={3}
-        centerOnInit
+        centerZoomedOut={false}
         limitToBounds={false}
         wheel={{ step: 0.1 }}
+        pinch={{ step: 5 }}
         doubleClick={{ mode: "reset" }}
+        onTransform={(ref, state) => {
+          // Auto-reset pan offset when zooming back out to 1:1
+          if (
+            state.scale <= 1 &&
+            (state.positionX !== 0 || state.positionY !== 0)
+          ) {
+            ref.resetTransform(0);
+          }
+        }}
       >
+        <ZoomControls />
         <TransformComponent
           wrapperClass="w-full h-full"
           contentClass="w-full h-full"

--- a/frontend/src/components/command/CommandCenterCanvas.tsx
+++ b/frontend/src/components/command/CommandCenterCanvas.tsx
@@ -86,25 +86,20 @@ export function CommandCenterCanvas({
 
   return (
     <div className="w-full h-full overflow-hidden relative">
+      {/* Same controls/feel as the floor views (shared ZoomControls, pinch,
+          resize-reset), but the Command Center area is taller than a single
+          office, so allow zooming out below 1:1 to reveal the bottom edge —
+          centerZoomedOut keeps the shrunk board centred in the viewport. */}
       <TransformWrapper
         ref={transformRef}
         initialScale={1}
-        minScale={1}
+        minScale={0.5}
         maxScale={3}
-        centerZoomedOut={false}
+        centerZoomedOut={true}
         limitToBounds={false}
         wheel={{ step: 0.1 }}
         pinch={{ step: 5 }}
         doubleClick={{ mode: "reset" }}
-        onTransform={(ref, state) => {
-          // Auto-reset pan offset when zooming back out to 1:1
-          if (
-            state.scale <= 1 &&
-            (state.positionX !== 0 || state.positionY !== 0)
-          ) {
-            ref.resetTransform(0);
-          }
-        }}
       >
         <ZoomControls />
         <TransformComponent

--- a/frontend/src/components/command/CommandCenterCanvas.tsx
+++ b/frontend/src/components/command/CommandCenterCanvas.tsx
@@ -1,0 +1,149 @@
+"use client";
+
+import { Application, extend } from "@pixi/react";
+import { Container, Text, Graphics, Sprite } from "pixi.js";
+import { useEffect, useRef, type ReactNode } from "react";
+import {
+  TransformWrapper,
+  TransformComponent,
+  type ReactZoomPanPinchRef,
+} from "react-zoom-pan-pinch";
+import { useOfficeTextures } from "@/hooks/useOfficeTextures";
+import {
+  CANVAS_WIDTH,
+  CANVAS_HEIGHT,
+  BACKGROUND_COLOR,
+} from "@/constants/canvas";
+import { useExitStore, useExitDriver } from "@/systems/exitAnimation";
+import {
+  setMotionTargets,
+  useMotionCleanup,
+} from "@/systems/commandCenterMotion";
+import { LoadingScreen } from "../game/LoadingScreen";
+import { WallClock } from "../game/WallClock";
+import { CommandCenterBackground } from "./CommandCenterBackground";
+import { CommandCenterZones } from "./CommandCenterZones";
+import { CommandCenterDecor } from "./CommandCenterDecor";
+import { CommandCenterFurniture } from "./CommandCenterFurniture";
+import { CommandCenterBoard } from "./CommandCenterBoard";
+import { CommandCenterPeer } from "./CommandCenterPeer";
+import { ExitingPeer } from "./ExitingPeer";
+import type { CommandPeer, CommandSummary } from "./useCommandCenterPeers";
+import type { ZoneKey } from "./layout";
+
+// Register the PixiJS components used by this canvas.
+extend({ Container, Text, Graphics, Sprite });
+
+interface CommandCenterCanvasProps {
+  peers: CommandPeer[];
+  counts: Record<ZoneKey, number>;
+  overflow: Record<ZoneKey, number>;
+  summary: CommandSummary;
+  onPeerActivate: (peer: CommandPeer, screen: { x: number; y: number }) => void;
+}
+
+export function CommandCenterCanvas({
+  peers,
+  counts,
+  overflow,
+  summary,
+  onPeerActivate,
+}: CommandCenterCanvasProps): ReactNode {
+  const transformRef = useRef<ReactZoomPanPinchRef>(null);
+  const { textures, loaded } = useOfficeTextures();
+
+  // Walk non-ended agents to their fixed slots (furniture stays put).
+  useMotionCleanup();
+  useEffect(() => {
+    setMotionTargets(
+      peers
+        .filter((p) => p.bucket !== "ended")
+        .map((p) => ({ id: p.sessionId, target: p.position })),
+    );
+  }, [peers]);
+
+  // Exit animation: only sessions seen active and then ended *while watching*
+  // walk out. Sessions already ended when the view opened are skipped.
+  useExitDriver();
+  const seenActiveRef = useRef<Set<string>>(new Set());
+  useEffect(() => {
+    const seen = seenActiveRef.current;
+    for (const p of peers) if (p.bucket !== "ended") seen.add(p.sessionId);
+    const exiting = peers
+      .filter((p) => p.bucket === "ended" && seen.has(p.sessionId))
+      .map((p) => p.sessionId);
+    useExitStore.getState().registerEnded(exiting, performance.now());
+  }, [peers]);
+
+  return (
+    <div className="w-full h-full overflow-hidden relative">
+      <TransformWrapper
+        ref={transformRef}
+        initialScale={1}
+        minScale={0.5}
+        maxScale={3}
+        centerOnInit
+        limitToBounds={false}
+        wheel={{ step: 0.1 }}
+        doubleClick={{ mode: "reset" }}
+      >
+        <TransformComponent
+          wrapperClass="w-full h-full"
+          contentClass="w-full h-full"
+        >
+          <div className="pixi-canvas-container w-full h-full">
+            <Application
+              width={CANVAS_WIDTH}
+              height={CANVAS_HEIGHT}
+              backgroundColor={BACKGROUND_COLOR}
+              autoDensity={true}
+              resolution={
+                typeof window !== "undefined" ? window.devicePixelRatio || 1 : 1
+              }
+            >
+              {!loaded && <LoadingScreen />}
+              {loaded && (
+                <>
+                  <CommandCenterBackground
+                    floorTileTexture={textures.floorTile}
+                  />
+                  <CommandCenterZones counts={counts} overflow={overflow} />
+                  <CommandCenterDecor textures={textures} />
+                  {/* Top-wall combined board + clock */}
+                  <pixiContainer x={430} y={66}>
+                    <CommandCenterBoard counts={counts} summary={summary} />
+                  </pixiContainer>
+                  <pixiContainer x={690} y={64}>
+                    <WallClock />
+                  </pixiContainer>
+                  <CommandCenterFurniture textures={textures} />
+                  <pixiContainer sortableChildren={true}>
+                    {peers.map((peer) =>
+                      peer.bucket === "ended" ? (
+                        <ExitingPeer
+                          key={peer.sessionId}
+                          peer={peer}
+                          headsetTexture={textures.headset}
+                          sunglassesTexture={textures.sunglasses}
+                          onActivate={onPeerActivate}
+                        />
+                      ) : (
+                        <CommandCenterPeer
+                          key={peer.sessionId}
+                          peer={peer}
+                          headsetTexture={textures.headset}
+                          sunglassesTexture={textures.sunglasses}
+                          onActivate={onPeerActivate}
+                        />
+                      ),
+                    )}
+                  </pixiContainer>
+                </>
+              )}
+            </Application>
+          </div>
+        </TransformComponent>
+      </TransformWrapper>
+    </div>
+  );
+}

--- a/frontend/src/components/command/CommandCenterDecor.tsx
+++ b/frontend/src/components/command/CommandCenterDecor.tsx
@@ -1,0 +1,102 @@
+"use client";
+
+import { type ReactNode } from "react";
+import type { OfficeTextures } from "@/hooks/useOfficeTextures";
+import { CANVAS_WIDTH } from "@/constants/canvas";
+import { TOP_WALL_H, FLOOR_DECOR_Y } from "./layout";
+
+interface CommandCenterDecorProps {
+  textures: OfficeTextures;
+}
+
+/**
+ * Open-plan decor using the existing office sprites: framed posters on the top
+ * wall, and a row of furniture (plants, printer, water cooler, coffee machine)
+ * along the bottom of the floor — placed in the empty band below the desks.
+ */
+export function CommandCenterDecor({
+  textures: t,
+}: CommandCenterDecorProps): ReactNode {
+  const wallY = TOP_WALL_H / 2 - 6;
+  const floorY = FLOOR_DECOR_Y + 40;
+
+  return (
+    <pixiContainer>
+      {/* ---- Top wall: posters at the edges (board + clock fill the centre) ---- */}
+      {t.employeeOfMonth && (
+        <>
+          <pixiSprite
+            texture={t.employeeOfMonth}
+            anchor={0.5}
+            x={96}
+            y={wallY}
+            scale={0.1}
+          />
+          <pixiSprite
+            texture={t.employeeOfMonth}
+            anchor={0.5}
+            x={CANVAS_WIDTH - 96}
+            y={wallY}
+            scale={0.1}
+          />
+        </>
+      )}
+      {t.wallOutlet && (
+        <pixiSprite
+          texture={t.wallOutlet}
+          anchor={0.5}
+          x={CANVAS_WIDTH - 220}
+          y={wallY + 4}
+          scale={0.045}
+        />
+      )}
+
+      {/* ---- Bottom floor furniture (base on the floor) ---- */}
+      {t.plant && (
+        <pixiSprite
+          texture={t.plant}
+          anchor={{ x: 0.5, y: 1 }}
+          x={70}
+          y={floorY}
+          scale={0.11}
+        />
+      )}
+      {t.printer && (
+        <pixiSprite
+          texture={t.printer}
+          anchor={{ x: 0.5, y: 1 }}
+          x={380}
+          y={floorY + 4}
+          scale={0.12}
+        />
+      )}
+      {t.waterCooler && (
+        <pixiSprite
+          texture={t.waterCooler}
+          anchor={{ x: 0.5, y: 1 }}
+          x={720}
+          y={floorY}
+          scale={0.19}
+        />
+      )}
+      {t.coffeeMachine && (
+        <pixiSprite
+          texture={t.coffeeMachine}
+          anchor={{ x: 0.5, y: 1 }}
+          x={1000}
+          y={floorY + 2}
+          scale={0.1}
+        />
+      )}
+      {t.plant && (
+        <pixiSprite
+          texture={t.plant}
+          anchor={{ x: 0.5, y: 1 }}
+          x={CANVAS_WIDTH - 60}
+          y={floorY}
+          scale={0.11}
+        />
+      )}
+    </pixiContainer>
+  );
+}

--- a/frontend/src/components/command/CommandCenterFurniture.tsx
+++ b/frontend/src/components/command/CommandCenterFurniture.tsx
@@ -1,0 +1,274 @@
+"use client";
+
+import { memo, useCallback, type ReactNode } from "react";
+import { Graphics, type Texture } from "pixi.js";
+import type { OfficeTextures } from "@/hooks/useOfficeTextures";
+import { useExitStore, selectDoorOpen } from "@/systems/exitAnimation";
+import { ZONES, MAX_SLOTS, slotPosition, type ZoneDef } from "./layout";
+
+// ============================================================================
+// DESK WORKSTATION (Needs-you / Working) — composed from real office sprites.
+// ============================================================================
+
+type DeskItem = "mug" | "lamp" | "penholder" | "8ball" | "rubiks" | "duck" | "thermos";
+const ITEM_SEQUENCE: DeskItem[] = [
+  "lamp",
+  "mug",
+  "8ball",
+  "rubiks",
+  "penholder",
+  "duck",
+  "thermos",
+  "lamp",
+];
+
+function accessory(
+  t: OfficeTextures,
+  item: DeskItem,
+): { tex: Texture | null; scale: number; y: number } {
+  switch (item) {
+    case "mug":
+      return { tex: t.coffeeMug, scale: 0.016, y: 26 };
+    case "lamp":
+      return { tex: t.deskLamp, scale: 0.23, y: 22 };
+    case "penholder":
+      return { tex: t.penHolder, scale: 0.14, y: 24 };
+    case "8ball":
+      return { tex: t.magic8Ball, scale: 0.1, y: 26 };
+    case "rubiks":
+      return { tex: t.rubiksCube, scale: 0.1, y: 26 };
+    case "duck":
+      return { tex: t.rubberDuck, scale: 0.1, y: 26 };
+    case "thermos":
+      return { tex: t.thermos, scale: 0.24, y: 24 };
+  }
+}
+
+function DeskComponent({
+  x,
+  y,
+  slot,
+  textures: t,
+}: {
+  x: number;
+  y: number;
+  slot: number;
+  textures: OfficeTextures;
+}): ReactNode {
+  const acc = accessory(t, ITEM_SEQUENCE[slot % ITEM_SEQUENCE.length]);
+  return (
+    <pixiContainer x={x} y={y} zIndex={y - 2}>
+      {t.chair && (
+        <pixiSprite
+          texture={t.chair}
+          anchor={{ x: 0.5, y: 1 }}
+          x={0}
+          y={8}
+          scale={0.088}
+        />
+      )}
+      {t.desk && (
+        <pixiSprite
+          texture={t.desk}
+          anchor={{ x: 0.5, y: 0 }}
+          x={0}
+          y={10}
+          scale={0.066}
+        />
+      )}
+      {t.keyboard && (
+        <pixiSprite
+          texture={t.keyboard}
+          anchor={0.5}
+          x={0}
+          y={24}
+          scale={0.026}
+        />
+      )}
+      {t.monitor && (
+        <pixiSprite
+          texture={t.monitor}
+          anchor={{ x: 0.5, y: 1 }}
+          x={-30}
+          y={20}
+          scale={0.052}
+        />
+      )}
+      {acc.tex && (
+        <pixiSprite
+          texture={acc.tex}
+          anchor={{ x: 0.5, y: 1 }}
+          x={32}
+          y={acc.y}
+          scale={acc.scale}
+        />
+      )}
+    </pixiContainer>
+  );
+}
+const Desk = memo(DeskComponent);
+
+// ============================================================================
+// LOUNGE COUCH (Done) — drawn; the lounge has no work desks.
+// ============================================================================
+
+function CouchComponent({ x, y }: { x: number; y: number }): ReactNode {
+  const draw = useCallback((g: Graphics) => {
+    g.clear();
+    const w = 92;
+    const seatY = 6;
+    // Shadow.
+    g.ellipse(0, seatY + 22, w / 2, 8);
+    g.fill({ color: 0x000000, alpha: 0.22 });
+    // Backrest.
+    g.roundRect(-w / 2, seatY - 26, w, 22, 8);
+    g.fill({ color: 0x3f5468 });
+    // Seat base.
+    g.roundRect(-w / 2, seatY - 8, w, 26, 8);
+    g.fill({ color: 0x4a6378 });
+    // Arms.
+    g.roundRect(-w / 2 - 6, seatY - 14, 14, 30, 6);
+    g.fill({ color: 0x37485a });
+    g.roundRect(w / 2 - 8, seatY - 14, 14, 30, 6);
+    g.fill({ color: 0x37485a });
+    // Cushions.
+    g.roundRect(-w / 2 + 8, seatY - 20, w / 2 - 12, 16, 5);
+    g.fill({ color: 0x577089 });
+    g.roundRect(4, seatY - 20, w / 2 - 12, 16, 5);
+    g.fill({ color: 0x577089 });
+  }, []);
+  return (
+    <pixiContainer x={x} y={y} zIndex={y - 2}>
+      <pixiGraphics draw={draw} />
+    </pixiContainer>
+  );
+}
+const Couch = memo(CouchComponent);
+
+// ============================================================================
+// EXIT (Ended) — the elevator doorway agents leave through. Reuses the office
+// elevator sprites + a drawn EXIT sign.
+// ============================================================================
+
+function ExitDoorComponent({
+  zone,
+  textures: t,
+}: {
+  zone: ZoneDef;
+  textures: OfficeTextures;
+}): ReactNode {
+  const cx = zone.x + zone.w / 2;
+  const baseY = zone.y + 150;
+  // Open the doors while an agent is stepping out.
+  const doorOpen = useExitStore(selectDoorOpen);
+
+  const drawSign = useCallback((g: Graphics) => {
+    g.clear();
+    g.roundRect(-34, -12, 68, 24, 4);
+    g.fill({ color: 0x14532d });
+    g.roundRect(-34, -12, 68, 24, 4);
+    g.stroke({ color: 0x22c55e, width: 2 });
+  }, []);
+
+  const drawDoor = useCallback((g: Graphics) => {
+    g.clear();
+    // Frame.
+    g.roundRect(-52, -150, 104, 150, 6);
+    g.fill({ color: 0x2b2f36 });
+    g.roundRect(-52, -150, 104, 150, 6);
+    g.stroke({ color: 0x4a5260, width: 3 });
+    // Door panels.
+    g.rect(-42, -140, 40, 138);
+    g.fill({ color: 0x3a4250 });
+    g.rect(2, -140, 40, 138);
+    g.fill({ color: 0x3a4250 });
+    g.rect(-2, -140, 4, 138);
+    g.fill({ color: 0x20242b });
+  }, []);
+
+  return (
+    <pixiContainer x={cx} y={baseY} zIndex={baseY - 4}>
+      {t.elevatorFrame ? (
+        <pixiSprite
+          texture={t.elevatorFrame}
+          anchor={{ x: 0.5, y: 1 }}
+          x={0}
+          y={4}
+          scale={0.26}
+        />
+      ) : (
+        <pixiGraphics draw={drawDoor} />
+      )}
+      {/* Closed doors — slide away (hidden) while someone is exiting */}
+      {t.elevatorDoor && !doorOpen && (
+        <pixiSprite
+          texture={t.elevatorDoor}
+          anchor={{ x: 0.5, y: 1 }}
+          x={0}
+          y={0}
+          scale={0.2}
+        />
+      )}
+      {/* EXIT sign above the doorway */}
+      <pixiContainer y={-168}>
+        <pixiGraphics draw={drawSign} />
+        <pixiContainer scale={0.5}>
+          <pixiText
+            text="EXIT"
+            anchor={0.5}
+            resolution={2}
+            style={{
+              fontFamily: "monospace",
+              fontSize: 26,
+              fill: 0x4ade80,
+              fontWeight: "bold",
+            }}
+          />
+        </pixiContainer>
+      </pixiContainer>
+    </pixiContainer>
+  );
+}
+const ExitDoor = memo(ExitDoorComponent);
+
+// ============================================================================
+// FURNITURE LAYER (static — drawn once, never follows agents)
+// ============================================================================
+
+function zoneFurniture(zone: ZoneDef, textures: OfficeTextures): ReactNode[] {
+  if (zone.kind === "exit") {
+    return [<ExitDoor key={`${zone.key}-exit`} zone={zone} textures={textures} />];
+  }
+  const items: ReactNode[] = [];
+  for (let slot = 0; slot < MAX_SLOTS; slot++) {
+    const p = slotPosition(zone, slot);
+    if (zone.kind === "lounge") {
+      items.push(<Couch key={`${zone.key}-${slot}`} x={p.x} y={p.y} />);
+    } else {
+      items.push(
+        <Desk
+          key={`${zone.key}-${slot}`}
+          x={p.x}
+          y={p.y}
+          slot={slot}
+          textures={textures}
+        />,
+      );
+    }
+  }
+  return items;
+}
+
+interface CommandCenterFurnitureProps {
+  textures: OfficeTextures;
+}
+
+export function CommandCenterFurniture({
+  textures,
+}: CommandCenterFurnitureProps): ReactNode {
+  return (
+    <pixiContainer sortableChildren={true}>
+      {ZONES.flatMap((zone) => zoneFurniture(zone, textures))}
+    </pixiContainer>
+  );
+}

--- a/frontend/src/components/command/CommandCenterFurniture.tsx
+++ b/frontend/src/components/command/CommandCenterFurniture.tsx
@@ -10,7 +10,14 @@ import { ZONES, MAX_SLOTS, slotPosition, type ZoneDef } from "./layout";
 // DESK WORKSTATION (Needs-you / Working) — composed from real office sprites.
 // ============================================================================
 
-type DeskItem = "mug" | "lamp" | "penholder" | "8ball" | "rubiks" | "duck" | "thermos";
+type DeskItem =
+  | "mug"
+  | "lamp"
+  | "penholder"
+  | "8ball"
+  | "rubiks"
+  | "duck"
+  | "thermos";
 const ITEM_SEQUENCE: DeskItem[] = [
   "lamp",
   "mug",
@@ -237,7 +244,9 @@ const ExitDoor = memo(ExitDoorComponent);
 
 function zoneFurniture(zone: ZoneDef, textures: OfficeTextures): ReactNode[] {
   if (zone.kind === "exit") {
-    return [<ExitDoor key={`${zone.key}-exit`} zone={zone} textures={textures} />];
+    return [
+      <ExitDoor key={`${zone.key}-exit`} zone={zone} textures={textures} />,
+    ];
   }
   const items: ReactNode[] = [];
   for (let slot = 0; slot < MAX_SLOTS; slot++) {

--- a/frontend/src/components/command/CommandCenterPeer.tsx
+++ b/frontend/src/components/command/CommandCenterPeer.tsx
@@ -1,0 +1,218 @@
+"use client";
+
+import { memo, useCallback, type ReactNode } from "react";
+import { Graphics, Texture } from "pixi.js";
+import type { Position } from "@/types";
+import { useMotionStore, selectMotionPos } from "@/systems/commandCenterMotion";
+import { ZONE_BY_KEY } from "./layout";
+import type { CommandPeer } from "./useCommandCenterPeers";
+
+// Body geometry (compact relative to the office BossSprite).
+const BODY_W = 40;
+const BODY_H = 58;
+const HEAD_R = 13;
+const HEAD_CY = -BODY_H + HEAD_R + 2;
+
+interface CommandCenterPeerProps {
+  peer: CommandPeer;
+  headsetTexture: Texture | null;
+  sunglassesTexture: Texture | null;
+  onActivate: (peer: CommandPeer, screen: { x: number; y: number }) => void;
+  /** Animated position (used by the exit walk); defaults to the fixed slot. */
+  positionOverride?: Position;
+  /** Container alpha (used to fade exiting agents). */
+  alphaOverride?: number;
+}
+
+function CommandCenterPeerComponent({
+  peer,
+  headsetTexture,
+  sunglassesTexture,
+  onActivate,
+  positionOverride,
+  alphaOverride,
+}: CommandCenterPeerProps): ReactNode {
+  const zone = ZONE_BY_KEY[peer.bucket];
+  const accent = zone.color;
+  const isNeedsYou = peer.bucket === "needs_you";
+  // Walked position from the motion mover; exit animation overrides it.
+  const motionPos = useMotionStore(selectMotionPos(peer.sessionId));
+  const pos = positionOverride ?? motionPos ?? peer.position;
+  const alpha = alphaOverride ?? 1;
+
+  const drawShadow = useCallback(
+    (g: Graphics) => {
+      g.clear();
+      // Status disc under the feet (stays grounded while the body bobs).
+      g.ellipse(0, 4, BODY_W / 2 + 4, 7);
+      g.fill({ color: accent, alpha: isNeedsYou ? 0.55 : 0.32 });
+    },
+    [accent, isNeedsYou],
+  );
+
+  const drawBody = useCallback(
+    (g: Graphics) => {
+      g.clear();
+      // Body capsule.
+      g.roundRect(-BODY_W / 2, -BODY_H, BODY_W, BODY_H, 14);
+      g.fill({ color: 0x2d3748 });
+      g.roundRect(-BODY_W / 2, -BODY_H, BODY_W, BODY_H, 14);
+      g.stroke({ color: accent, width: isNeedsYou ? 4 : 2.5, alpha: 0.95 });
+      // Head.
+      g.circle(0, HEAD_CY, HEAD_R);
+      g.fill({ color: 0x1f2937 });
+    },
+    [accent, isNeedsYou],
+  );
+
+  const drawTodoBar = useCallback(
+    (g: Graphics) => {
+      g.clear();
+      const w = 46;
+      const h = 6;
+      const ratio = peer.todoTotal > 0 ? peer.todoDone / peer.todoTotal : 0;
+      g.roundRect(-w / 2, 0, w, h, 3);
+      g.fill({ color: 0x0f172a });
+      g.roundRect(-w / 2, 0, w, h, 3);
+      g.stroke({ color: 0x334155, width: 1 });
+      if (ratio > 0) {
+        g.roundRect(-w / 2, 0, Math.max(3, w * ratio), h, 3);
+        g.fill({ color: accent });
+      }
+    },
+    [peer.todoDone, peer.todoTotal, accent],
+  );
+
+  const drawBadge = useCallback((g: Graphics) => {
+    g.clear();
+    g.roundRect(0, 0, 26, 16, 8);
+    g.fill({ color: 0x111827 });
+    g.roundRect(0, 0, 26, 16, 8);
+    g.stroke({ color: 0xf59e0b, width: 1.5, alpha: 0.9 });
+  }, []);
+
+  // Office-style nameplate behind the project label.
+  const shortLabel =
+    peer.label.length > 16 ? `${peer.label.slice(0, 15)}…` : peer.label;
+  const plateW = shortLabel.length * 12 + 22; // 2x units (container scaled 0.5)
+  const drawPlate = useCallback(
+    (g: Graphics) => {
+      g.clear();
+      g.roundRect(-plateW / 2, -15, plateW, 28, 7);
+      g.fill({ color: 0x1e1e1e, alpha: 0.88 });
+      g.roundRect(-plateW / 2, -15, plateW, 28, 7);
+      g.stroke({ color: accent, width: 1.5, alpha: 0.65 });
+    },
+    [plateW, accent],
+  );
+
+  const handleTap = useCallback(
+    (e: {
+      client?: { x: number; y: number };
+      global?: { x: number; y: number };
+    }) => {
+      // DOM client coords so the popover lands under the cursor.
+      const p = e.client ?? e.global ?? { x: 0, y: 0 };
+      onActivate(peer, { x: p.x, y: p.y });
+    },
+    [onActivate, peer],
+  );
+
+  return (
+    <pixiContainer
+      x={pos.x}
+      y={pos.y}
+      zIndex={pos.y}
+      alpha={alpha}
+      eventMode="static"
+      cursor="pointer"
+      onPointerTap={handleTap}
+    >
+      <pixiGraphics draw={drawShadow} />
+
+      <pixiContainer>
+        <pixiGraphics draw={drawBody} />
+
+        {/* Sunglasses */}
+        {sunglassesTexture && (
+          <pixiSprite
+            texture={sunglassesTexture}
+            anchor={0.5}
+            x={0}
+            y={HEAD_CY + 1}
+            scale={{ x: 0.03, y: 0.034 }}
+            tint={0x000000}
+          />
+        )}
+
+        {/* Headset */}
+        {headsetTexture && (
+          <pixiSprite
+            texture={headsetTexture}
+            anchor={0.5}
+            x={0}
+            y={HEAD_CY}
+            scale={{ x: 0.56, y: 0.57 }}
+          />
+        )}
+      </pixiContainer>
+
+      {/* Project nameplate */}
+      <pixiContainer y={-BODY_H - 16} scale={0.5}>
+        <pixiGraphics draw={drawPlate} />
+        <pixiText
+          text={shortLabel}
+          anchor={0.5}
+          resolution={2}
+          style={{
+            fontFamily: "monospace",
+            fontSize: 20,
+            fill: 0xffffff,
+            fontWeight: "bold",
+          }}
+        />
+      </pixiContainer>
+
+      {/* Subagent count badge */}
+      {peer.subagentCount > 0 && (
+        <pixiContainer x={BODY_W / 2 - 2} y={-BODY_H + 4}>
+          <pixiGraphics draw={drawBadge} />
+          <pixiContainer x={13} y={8} scale={0.5}>
+            <pixiText
+              text={`+${peer.subagentCount}`}
+              anchor={0.5}
+              resolution={2}
+              style={{
+                fontFamily: "monospace",
+                fontSize: 18,
+                fill: 0xf59e0b,
+                fontWeight: "bold",
+              }}
+            />
+          </pixiContainer>
+        </pixiContainer>
+      )}
+
+      {/* Todo progress bar */}
+      {peer.todoTotal > 0 && (
+        <pixiContainer y={12}>
+          <pixiGraphics draw={drawTodoBar} />
+          <pixiContainer x={0} y={8} scale={0.5}>
+            <pixiText
+              text={`${peer.todoDone}/${peer.todoTotal}`}
+              anchor={{ x: 0.5, y: 0 }}
+              resolution={2}
+              style={{
+                fontFamily: "monospace",
+                fontSize: 14,
+                fill: 0x94a3b8,
+              }}
+            />
+          </pixiContainer>
+        </pixiContainer>
+      )}
+    </pixiContainer>
+  );
+}
+
+export const CommandCenterPeer = memo(CommandCenterPeerComponent);

--- a/frontend/src/components/command/CommandCenterView.tsx
+++ b/frontend/src/components/command/CommandCenterView.tsx
@@ -10,7 +10,6 @@ import {
   selectOverviewConnected,
 } from "@/stores/overviewStore";
 import { useNavigationStore } from "@/stores/navigationStore";
-import type { FloorConfig } from "@/types/navigation";
 import type { Session } from "@/hooks/useSessions";
 import {
   useCommandCenterPeers,
@@ -18,18 +17,7 @@ import {
 } from "./useCommandCenterPeers";
 import { PeerPopup, type PeerPopupState } from "./PeerPopup";
 import { ZONE_BY_KEY, ZONE_ORDER } from "./layout";
-
-/** Whether a session belongs to a configured floor (repo-name match). */
-function sessionMatchesFloor(session: Session, floor: FloorConfig): boolean {
-  return floor.rooms.some((room) => {
-    if (!room.repoName) return false;
-    if (session.projectRoot) {
-      const basename = session.projectRoot.split(/[/\\]/).pop();
-      if (basename === room.repoName) return true;
-    }
-    return session.projectName === room.repoName;
-  });
-}
+import { sessionMatchesFloor } from "./sessionMatchesFloor";
 
 function CommandCenterLoading(): ReactNode {
   const { t } = useTranslation();
@@ -91,10 +79,11 @@ export function CommandCenterView({
   );
 
   // Drill into a session: select it, then land in its floor (if configured) or
-  // the single office view.
+  // the single office view. Await the select so the target view mounts on the
+  // new session instead of reading the old one for a frame.
   const handleDrillIn = useCallback(
-    (sid: string) => {
-      void onSessionSelect(sid);
+    async (sid: string) => {
+      await onSessionSelect(sid);
       const nav = useNavigationStore.getState();
       const session = sessions.find((s) => s.id === sid);
       const floor = session

--- a/frontend/src/components/command/CommandCenterView.tsx
+++ b/frontend/src/components/command/CommandCenterView.tsx
@@ -1,0 +1,172 @@
+"use client";
+
+import dynamic from "next/dynamic";
+import { useCallback, useState, type ReactNode } from "react";
+import { SessionSidebar } from "@/components/layout/SessionSidebar";
+import { useTranslation } from "@/hooks/useTranslation";
+import { useOverviewWebSocket } from "@/hooks/useOverviewWebSocket";
+import {
+  useOverviewStore,
+  selectOverviewConnected,
+} from "@/stores/overviewStore";
+import { useNavigationStore } from "@/stores/navigationStore";
+import type { FloorConfig } from "@/types/navigation";
+import type { Session } from "@/hooks/useSessions";
+import { useCommandCenterPeers, type CommandPeer } from "./useCommandCenterPeers";
+import { PeerPopup, type PeerPopupState } from "./PeerPopup";
+import { ZONE_BY_KEY, ZONE_ORDER } from "./layout";
+
+/** Whether a session belongs to a configured floor (repo-name match). */
+function sessionMatchesFloor(session: Session, floor: FloorConfig): boolean {
+  return floor.rooms.some((room) => {
+    if (!room.repoName) return false;
+    if (session.projectRoot) {
+      const basename = session.projectRoot.split("/").pop();
+      if (basename === room.repoName) return true;
+    }
+    return session.projectName === room.repoName;
+  });
+}
+
+// Canvas is PixiJS/WebGL — load client-side only.
+const CommandCenterCanvas = dynamic(
+  () => import("./CommandCenterCanvas").then((m) => ({ default: m.CommandCenterCanvas })),
+  {
+    ssr: false,
+    loading: () => (
+      <div className="w-full h-full bg-slate-900 animate-pulse flex items-center justify-center text-white font-mono text-center">
+        Initializing Command Center...
+      </div>
+    ),
+  },
+);
+
+export interface CommandCenterViewProps {
+  sessions: Session[];
+  sessionsLoading: boolean;
+  sessionId: string;
+  isCollapsed: boolean;
+  onToggleCollapsed: () => void;
+  onSessionSelect: (id: string) => Promise<void>;
+  onDeleteSession: (session: Session) => void;
+  onRenameSession: (sessionId: string, newName: string) => Promise<void>;
+}
+
+export function CommandCenterView({
+  sessions,
+  sessionsLoading,
+  sessionId,
+  isCollapsed,
+  onToggleCollapsed,
+  onSessionSelect,
+  onDeleteSession,
+  onRenameSession,
+}: CommandCenterViewProps): ReactNode {
+  const { t } = useTranslation();
+  // Connect to /ws/overview for as long as this view is mounted.
+  useOverviewWebSocket({ enabled: true });
+  const connected = useOverviewStore(selectOverviewConnected);
+
+  const { peers, counts, overflow, summary } = useCommandCenterPeers(sessions);
+
+  const [popup, setPopup] = useState<PeerPopupState | null>(null);
+
+  // Click a peer → open its popover (choose: open terminal, or drill in).
+  const handlePeerActivate = useCallback(
+    (peer: CommandPeer, screen: { x: number; y: number }) => {
+      setPopup({ peer, x: screen.x, y: screen.y });
+    },
+    [],
+  );
+
+  // Drill into a session: select it, then land in its floor (if configured) or
+  // the single office view.
+  const handleDrillIn = useCallback(
+    (sid: string) => {
+      void onSessionSelect(sid);
+      const nav = useNavigationStore.getState();
+      const session = sessions.find((s) => s.id === sid);
+      const floor = session
+        ? nav.buildingConfig?.floors.find((f) =>
+            sessionMatchesFloor(session, f),
+          )
+        : undefined;
+      if (floor) {
+        nav.goToFloor(floor.id);
+      } else {
+        nav.goToSingle();
+      }
+    },
+    [onSessionSelect, sessions],
+  );
+
+  return (
+    <div className="flex-grow flex gap-2 overflow-hidden min-h-0">
+      <SessionSidebar
+        sessions={sessions}
+        sessionsLoading={sessionsLoading}
+        sessionId={sessionId}
+        isCollapsed={isCollapsed}
+        onToggleCollapsed={onToggleCollapsed}
+        onSessionSelect={onSessionSelect}
+        onDeleteSession={onDeleteSession}
+        onRenameSession={onRenameSession}
+      />
+
+      <div className="flex-grow flex flex-col gap-2 min-h-0">
+        {/* Summary bar */}
+        <div className="flex items-center gap-3 px-3 py-2 rounded-lg border border-slate-800 bg-slate-900 shrink-0">
+          <span className="text-sm font-bold text-white tracking-tight">
+            {t("commandCenter.title")}
+          </span>
+          <div className="flex items-center gap-3 flex-grow">
+            {ZONE_ORDER.map((key) => {
+              const zone = ZONE_BY_KEY[key];
+              return (
+                <span
+                  key={key}
+                  className="flex items-center gap-1.5 text-xs font-mono text-slate-300"
+                >
+                  <span
+                    className="w-2 h-2 rounded-full"
+                    style={{ backgroundColor: zone.cssColor }}
+                  />
+                  {counts[key] ?? 0} {t(zone.labelKey)}
+                </span>
+              );
+            })}
+          </div>
+          <span
+            className={`flex items-center gap-1.5 text-xs font-mono ${
+              connected ? "text-emerald-400" : "text-rose-500"
+            }`}
+          >
+            <span
+              className={`w-2 h-2 rounded-full ${
+                connected ? "bg-emerald-400 animate-pulse" : "bg-rose-500"
+              }`}
+            />
+            {connected ? t("header.connected") : t("header.disconnected")}
+          </span>
+        </div>
+
+        {/* Canvas */}
+        <div className="flex-grow border border-slate-800 rounded-lg shadow-2xl bg-slate-900 overflow-hidden relative min-h-0">
+          <CommandCenterCanvas
+            peers={peers}
+            counts={counts}
+            overflow={overflow}
+            summary={summary}
+            onPeerActivate={handlePeerActivate}
+          />
+        </div>
+      </div>
+
+      <PeerPopup
+        popup={popup}
+        onClose={() => setPopup(null)}
+        onDrillIn={handleDrillIn}
+      />
+    </div>
+  );
+}

--- a/frontend/src/components/command/CommandCenterView.tsx
+++ b/frontend/src/components/command/CommandCenterView.tsx
@@ -12,7 +12,10 @@ import {
 import { useNavigationStore } from "@/stores/navigationStore";
 import type { FloorConfig } from "@/types/navigation";
 import type { Session } from "@/hooks/useSessions";
-import { useCommandCenterPeers, type CommandPeer } from "./useCommandCenterPeers";
+import {
+  useCommandCenterPeers,
+  type CommandPeer,
+} from "./useCommandCenterPeers";
 import { PeerPopup, type PeerPopupState } from "./PeerPopup";
 import { ZONE_BY_KEY, ZONE_ORDER } from "./layout";
 
@@ -21,23 +24,31 @@ function sessionMatchesFloor(session: Session, floor: FloorConfig): boolean {
   return floor.rooms.some((room) => {
     if (!room.repoName) return false;
     if (session.projectRoot) {
-      const basename = session.projectRoot.split("/").pop();
+      const basename = session.projectRoot.split(/[/\\]/).pop();
       if (basename === room.repoName) return true;
     }
     return session.projectName === room.repoName;
   });
 }
 
+function CommandCenterLoading(): ReactNode {
+  const { t } = useTranslation();
+  return (
+    <div className="w-full h-full bg-slate-900 animate-pulse flex items-center justify-center text-white font-mono text-center">
+      {t("commandCenter.initializing")}
+    </div>
+  );
+}
+
 // Canvas is PixiJS/WebGL — load client-side only.
 const CommandCenterCanvas = dynamic(
-  () => import("./CommandCenterCanvas").then((m) => ({ default: m.CommandCenterCanvas })),
+  () =>
+    import("./CommandCenterCanvas").then((m) => ({
+      default: m.CommandCenterCanvas,
+    })),
   {
     ssr: false,
-    loading: () => (
-      <div className="w-full h-full bg-slate-900 animate-pulse flex items-center justify-center text-white font-mono text-center">
-        Initializing Command Center...
-      </div>
-    ),
+    loading: () => <CommandCenterLoading />,
   },
 );
 

--- a/frontend/src/components/command/CommandCenterZones.tsx
+++ b/frontend/src/components/command/CommandCenterZones.tsx
@@ -1,0 +1,105 @@
+"use client";
+
+import { useCallback, type ReactNode } from "react";
+import { Graphics } from "pixi.js";
+import { useTranslation } from "@/hooks/useTranslation";
+import { ZONES, MAX_SLOTS, type ZoneDef, type ZoneKey } from "./layout";
+
+const BAND_INSET = 8;
+const HEADER_H = 36;
+
+interface ZoneColumnProps {
+  zone: ZoneDef;
+  count: number;
+  overflow: number;
+}
+
+function ZoneColumn({ zone, count, overflow }: ZoneColumnProps): ReactNode {
+  const { t } = useTranslation();
+  const x = zone.x + BAND_INSET;
+  const y = zone.y + 6;
+  const w = zone.w - BAND_INSET * 2;
+  const h = zone.h - 16;
+
+  const drawBand = useCallback(
+    (g: Graphics) => {
+      g.clear();
+      // Status-tinted floor band down the column.
+      g.roundRect(x, y, w, h, 10);
+      g.fill({ color: zone.color, alpha: 0.06 });
+      g.roundRect(x, y, w, h, 10);
+      g.stroke({ color: zone.color, width: 1.5, alpha: 0.3 });
+      // Header plate.
+      g.roundRect(x, y, w, HEADER_H, 10);
+      g.fill({ color: zone.color, alpha: 0.18 });
+      g.roundRect(x + 6, y + 6, w - 12, HEADER_H - 12, 5);
+      g.fill({ color: 0x1e1e1e, alpha: 0.5 });
+    },
+    [x, y, w, h, zone.color],
+  );
+
+  return (
+    <pixiContainer>
+      <pixiGraphics draw={drawBand} />
+      {/* Header label (exit column omits the count — agents just leave) */}
+      <pixiContainer x={x + w / 2} y={y + HEADER_H / 2} scale={0.5}>
+        <pixiText
+          text={
+            zone.kind === "exit"
+              ? `${zone.emoji}  ${t(zone.labelKey).toUpperCase()}`
+              : `${zone.emoji}  ${t(zone.labelKey).toUpperCase()}  (${count})`
+          }
+          anchor={0.5}
+          resolution={2}
+          style={{
+            fontFamily: "monospace",
+            fontSize: 24,
+            fill: zone.color,
+            fontWeight: "bold",
+          }}
+        />
+      </pixiContainer>
+      {/* Overflow tag */}
+      {overflow > 0 && (
+        <pixiContainer x={x + w / 2} y={y + h - 16} scale={0.5}>
+          <pixiText
+            text={t("commandCenter.moreCount", { count: overflow })}
+            anchor={{ x: 0.5, y: 1 }}
+            resolution={2}
+            style={{
+              fontFamily: "monospace",
+              fontSize: 22,
+              fill: 0xcbd5e1,
+              fontWeight: "bold",
+            }}
+          />
+        </pixiContainer>
+      )}
+    </pixiContainer>
+  );
+}
+
+interface CommandCenterZonesProps {
+  counts: Record<ZoneKey, number>;
+  overflow: Record<ZoneKey, number>;
+}
+
+export function CommandCenterZones({
+  counts,
+  overflow,
+}: CommandCenterZonesProps): ReactNode {
+  return (
+    <pixiContainer>
+      {ZONES.map((zone) => (
+        <ZoneColumn
+          key={zone.key}
+          zone={zone}
+          count={counts[zone.key] ?? 0}
+          overflow={overflow[zone.key] ?? 0}
+        />
+      ))}
+    </pixiContainer>
+  );
+}
+
+export { MAX_SLOTS };

--- a/frontend/src/components/command/ExitingPeer.tsx
+++ b/frontend/src/components/command/ExitingPeer.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import { type ReactNode } from "react";
+import type { Texture } from "pixi.js";
+import { useExitStore, exitProgress } from "@/systems/exitAnimation";
+import { CommandCenterPeer } from "./CommandCenterPeer";
+import { ZONE_BY_KEY } from "./layout";
+import type { CommandPeer } from "./useCommandCenterPeers";
+
+// The elevator doorway sits at the top-centre of the Ended column (see
+// CommandCenterFurniture ExitDoor: baseY = zone.y + 150).
+const ended = ZONE_BY_KEY.ended;
+const DOOR_X = ended.x + ended.w / 2;
+const DOOR_BASE_Y = ended.y + 150;
+const START_Y = DOOR_BASE_Y + 90; // queue spot below the door
+const THRESHOLD_Y = DOOR_BASE_Y - 34; // doorway entrance
+const INSIDE_Y = DOOR_BASE_Y - 78; // stepped inside
+
+const lerp = (a: number, b: number, t: number): number => a + (b - a) * t;
+
+interface ExitingPeerProps {
+  peer: CommandPeer;
+  headsetTexture: Texture | null;
+  sunglassesTexture: Texture | null;
+  onActivate: (peer: CommandPeer, screen: { x: number; y: number }) => void;
+}
+
+/**
+ * Renders an Ended agent walking to the elevator and stepping out. Subscribes
+ * to the per-frame exit clock; once the walk-out completes the agent is gone.
+ */
+export function ExitingPeer({
+  peer,
+  headsetTexture,
+  sunglassesTexture,
+  onActivate,
+}: ExitingPeerProps): ReactNode {
+  const now = useExitStore((s) => s.now);
+  const startTimes = useExitStore((s) => s.startTimes);
+
+  // Only sessions that ended *while watching* are registered; others (ended
+  // before the view opened) are treated as already gone.
+  if (!startTimes.has(peer.sessionId)) return null;
+
+  const p = exitProgress(peer.sessionId, now, startTimes);
+  if (p >= 1) return null; // walked out — gone.
+
+  let y: number;
+  let alpha: number;
+  if (p < 0.55) {
+    // Walk up to the doorway.
+    y = lerp(START_Y, THRESHOLD_Y, p / 0.55);
+    alpha = 1;
+  } else {
+    // Step inside and fade.
+    const t = (p - 0.55) / 0.45;
+    y = lerp(THRESHOLD_Y, INSIDE_Y, t);
+    alpha = 1 - t;
+  }
+
+  return (
+    <CommandCenterPeer
+      peer={peer}
+      headsetTexture={headsetTexture}
+      sunglassesTexture={sunglassesTexture}
+      onActivate={onActivate}
+      positionOverride={{ x: DOOR_X, y }}
+      alphaOverride={alpha}
+    />
+  );
+}

--- a/frontend/src/components/command/PeerPopup.tsx
+++ b/frontend/src/components/command/PeerPopup.tsx
@@ -1,0 +1,154 @@
+"use client";
+
+import { useCallback, useEffect, type ReactNode } from "react";
+import { createPortal } from "react-dom";
+import { Terminal, ArrowRight } from "lucide-react";
+import { useAttentionStore } from "@/stores/attentionStore";
+import { useTranslation } from "@/hooks/useTranslation";
+import { ZONE_BY_KEY } from "./layout";
+import type { CommandPeer } from "./useCommandCenterPeers";
+
+const POPUP_WIDTH = 260;
+const POPUP_MARGIN = 16;
+
+export interface PeerPopupState {
+  peer: CommandPeer;
+  x: number;
+  y: number;
+}
+
+interface PeerPopupProps {
+  popup: PeerPopupState | null;
+  onClose: () => void;
+  onDrillIn: (sessionId: string) => void;
+}
+
+/**
+ * Cross-session peer popover. Unlike the office {@link AgentPopup} (bound to the
+ * active session's game store), this takes the peer's own session id, so the
+ * "open terminal" action always targets exactly that one agent's terminal.
+ */
+export function PeerPopup({
+  popup,
+  onClose,
+  onDrillIn,
+}: PeerPopupProps): ReactNode {
+  const { t } = useTranslation();
+  const focusAgentTerminal = useAttentionStore((s) => s.focusAgentTerminal);
+
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    },
+    [onClose],
+  );
+
+  useEffect(() => {
+    if (!popup) return;
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [popup, handleKeyDown]);
+
+  if (!popup) return null;
+  if (typeof document === "undefined") return null;
+
+  const { peer } = popup;
+  const zone = ZONE_BY_KEY[peer.bucket];
+
+  // Viewport-clamped positioning.
+  const vw = window.innerWidth;
+  const vh = window.innerHeight;
+  let x = popup.x + 16;
+  let y = popup.y - 40;
+  if (x + POPUP_WIDTH > vw - POPUP_MARGIN) x = popup.x - POPUP_WIDTH - 16;
+  if (y + 220 > vh - POPUP_MARGIN) y = vh - 220 - POPUP_MARGIN;
+  if (y < POPUP_MARGIN) y = POPUP_MARGIN;
+
+  const handleFocusTerminal = () => {
+    // peer.sessionId is this agent's own terminal — focus exactly that one.
+    void focusAgentTerminal(peer.sessionId, null);
+    onClose();
+  };
+
+  const handleDrill = () => {
+    onDrillIn(peer.sessionId);
+    onClose();
+  };
+
+  const content = (
+    <div
+      className="fixed inset-0 z-[90]"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onClose();
+      }}
+    >
+      <div
+        className="absolute bg-neutral-900 border border-neutral-700 rounded-xl shadow-2xl p-4"
+        style={{ left: x, top: y, width: POPUP_WIDTH }}
+      >
+        <div className="flex items-center gap-2 mb-3">
+          <div
+            className="w-3 h-3 rounded-full shrink-0"
+            style={{ backgroundColor: zone.cssColor }}
+          />
+          <span className="text-white font-bold text-sm truncate flex-1">
+            {peer.label}
+          </span>
+        </div>
+
+        <div className="text-[12px] text-neutral-400 space-y-1 mb-3">
+          <div>
+            <span className="text-neutral-600">
+              {t("attention.popup.state")}:
+            </span>{" "}
+            {`${zone.emoji} ${t(zone.labelKey)}`}
+            {peer.state ? ` (${peer.state})` : ""}
+          </div>
+          {peer.currentTask && (
+            <div className="truncate">
+              <span className="text-neutral-600">
+                {t("attention.popup.task")}:
+              </span>{" "}
+              {peer.currentTask}
+            </div>
+          )}
+          {peer.todoTotal > 0 && (
+            <div>
+              <span className="text-neutral-600">
+                {t("commandCenter.popup.todos")}:
+              </span>{" "}
+              {peer.todoDone}/{peer.todoTotal}
+            </div>
+          )}
+          {peer.subagentCount > 0 && (
+            <div>
+              <span className="text-neutral-600">
+                {t("commandCenter.popup.employees")}:
+              </span>{" "}
+              {peer.subagentCount}
+            </div>
+          )}
+        </div>
+
+        <div className="flex gap-2">
+          <button
+            onClick={handleFocusTerminal}
+            className="flex-1 flex items-center justify-center gap-1.5 bg-blue-500 hover:bg-blue-600 text-white text-xs font-bold py-1.5 px-3 rounded-lg transition-colors"
+          >
+            <Terminal size={13} />
+            {t("commandCenter.popup.terminal")}
+          </button>
+          <button
+            onClick={handleDrill}
+            className="flex-1 flex items-center justify-center gap-1.5 bg-sky-500/20 hover:bg-sky-500/30 text-sky-300 text-xs font-bold py-1.5 px-3 rounded-lg transition-colors"
+          >
+            <ArrowRight size={13} />
+            {t("commandCenter.popup.drillIn")}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+
+  return createPortal(content, document.body);
+}

--- a/frontend/src/components/command/layout.ts
+++ b/frontend/src/components/command/layout.ts
@@ -1,0 +1,120 @@
+/**
+ * Command Center layout — "Open Plan / Columns".
+ *
+ * A single open office floor (matching the main office) with a decorated top
+ * wall. The floor is split into four vertical status columns (left→right by
+ * priority): Needs-you, Working, Done, Ended. Each column holds a 2×4 grid of
+ * workstations; overflow is summarised as "+N more".
+ */
+
+import type { OverviewBucket, Position } from "@/types";
+import type { TranslationKey } from "@/i18n";
+import { CANVAS_WIDTH, CANVAS_HEIGHT } from "@/constants/canvas";
+
+/** Status columns, including the frontend-only "ended" bucket. */
+export type ZoneKey = OverviewBucket | "ended";
+
+/** What fixed furniture a column shows. */
+export type ZoneKind = "desks" | "lounge" | "exit";
+
+export interface ZoneDef {
+  key: ZoneKey;
+  kind: ZoneKind;
+  labelKey: TranslationKey;
+  emoji: string;
+  color: number; // PixiJS hex
+  cssColor: string;
+  x: number; // column left
+  y: number; // column top (floor top)
+  w: number; // column width
+  h: number; // column height
+}
+
+/** Height of the decorated top wall strip. */
+export const TOP_WALL_H = 140;
+/** Floor furniture strip begins here (below the desk grid). */
+export const FLOOR_DECOR_Y = CANVAS_HEIGHT - 96;
+
+const COL_W = CANVAS_WIDTH / 4; // 320
+const FLOOR_TOP = TOP_WALL_H;
+const FLOOR_H = CANVAS_HEIGHT - TOP_WALL_H;
+
+const COL_DEFS: Array<{
+  key: ZoneKey;
+  kind: ZoneKind;
+  labelKey: TranslationKey;
+  emoji: string;
+  color: number;
+  cssColor: string;
+}> = [
+  {
+    key: "needs_you",
+    kind: "desks",
+    labelKey: "commandCenter.zone.needsYou",
+    emoji: "⚠",
+    color: 0xfbbf24,
+    cssColor: "#fbbf24",
+  },
+  {
+    key: "working",
+    kind: "desks",
+    labelKey: "commandCenter.zone.working",
+    emoji: "\u{1F7E2}",
+    color: 0x22c55e,
+    cssColor: "#22c55e",
+  },
+  {
+    key: "done",
+    kind: "lounge",
+    labelKey: "commandCenter.zone.done",
+    emoji: "✅",
+    color: 0x3b82f6,
+    cssColor: "#3b82f6",
+  },
+  {
+    key: "ended",
+    kind: "exit",
+    labelKey: "commandCenter.zone.ended",
+    emoji: "⚪",
+    color: 0x64748b,
+    cssColor: "#64748b",
+  },
+];
+
+export const ZONES: ZoneDef[] = COL_DEFS.map((c, i) => ({
+  ...c,
+  x: i * COL_W,
+  y: FLOOR_TOP,
+  w: COL_W,
+  h: FLOOR_H,
+}));
+
+export const ZONE_ORDER: ZoneKey[] = ["needs_you", "working", "done", "ended"];
+
+export const ZONE_BY_KEY: Record<ZoneKey, ZoneDef> = ZONES.reduce(
+  (acc, z) => {
+    acc[z.key] = z;
+    return acc;
+  },
+  {} as Record<ZoneKey, ZoneDef>,
+);
+
+// Workstation grid within a column: 2 sub-columns × 4 rows.
+const SLOT_COLS = 2;
+const HEADER_H = 44;
+const COL_PAD_X = 16;
+const SUB_COL_GAP = 152;
+const ROW_TOP = FLOOR_TOP + HEADER_H + 70; // first row's feet
+const ROW_GAP = 168;
+
+/** Max visible workstations per column before collapsing to "+N more". */
+export const MAX_SLOTS = SLOT_COLS * 4; // 8
+
+/** Pixel position (agent feet) for the slot at *index* within *zone* (column). */
+export function slotPosition(zone: ZoneDef, index: number): Position {
+  const col = index % SLOT_COLS;
+  const row = Math.floor(index / SLOT_COLS);
+  const x = zone.x + COL_PAD_X + 68 + col * SUB_COL_GAP;
+  const y = ROW_TOP + row * ROW_GAP;
+  return { x, y };
+}

--- a/frontend/src/components/command/sessionMatchesFloor.ts
+++ b/frontend/src/components/command/sessionMatchesFloor.ts
@@ -1,0 +1,17 @@
+import type { FloorConfig } from "@/types/navigation";
+import type { Session } from "@/hooks/useSessions";
+
+/** Whether a session belongs to a configured floor (repo-name match). */
+export function sessionMatchesFloor(
+  session: Session,
+  floor: FloorConfig,
+): boolean {
+  return floor.rooms.some((room) => {
+    if (!room.repoName) return false;
+    if (session.projectRoot) {
+      const basename = session.projectRoot.split(/[/\\]/).pop();
+      if (basename === room.repoName) return true;
+    }
+    return session.projectName === room.repoName;
+  });
+}

--- a/frontend/src/components/command/useCommandCenterPeers.ts
+++ b/frontend/src/components/command/useCommandCenterPeers.ts
@@ -1,0 +1,226 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { useOverviewStore, selectOverviewEntries } from "@/stores/overviewStore";
+import type { BossState, Position } from "@/types";
+import type { Session } from "@/hooks/useSessions";
+import {
+  MAX_SLOTS,
+  ZONE_BY_KEY,
+  ZONE_ORDER,
+  slotPosition,
+  type ZoneKey,
+} from "./layout";
+
+// Ended sessions linger in the Ended zone for this long after they finish.
+const RECENT_ENDED_MS = 30 * 60 * 1000;
+
+export interface CommandPeer {
+  sessionId: string;
+  label: string;
+  bucket: ZoneKey;
+  state: BossState | null;
+  currentTask: string | null;
+  todoDone: number;
+  todoTotal: number;
+  subagentCount: number;
+  slotIndex: number;
+  /** Static slot position (Phase B). Walking between slots lands in Phase C. */
+  position: Position;
+}
+
+/** Combined cross-session totals shown on the Command Center board. */
+export interface CommandSummary {
+  /** Live terminals (active = needs-you + working + done). */
+  terminals: number;
+  /** Total active subagents across all sessions. */
+  subagents: number;
+  todoDone: number;
+  todoTotal: number;
+}
+
+export interface CommandCenterPeers {
+  peers: CommandPeer[];
+  counts: Record<ZoneKey, number>;
+  overflow: Record<ZoneKey, number>;
+  summary: CommandSummary;
+}
+
+function labelFor(session: Session | undefined, sessionId: string): string {
+  return (
+    session?.projectName ||
+    session?.displayName ||
+    session?.label ||
+    sessionId.slice(0, 8)
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Free-slot allocator (module-level so it persists across renders).
+// Each session claims the lowest free slot in its column and KEEPS it until it
+// leaves or changes column — agents don't reshuffle when others come and go.
+// Idempotent (safe under double-render).
+// ---------------------------------------------------------------------------
+const slotAlloc = new Map<string, { bucket: ZoneKey; slot: number }>();
+
+function assignSlots(
+  presentByBucket: Map<ZoneKey, string[]>,
+): Map<string, number> {
+  const bucketOf = new Map<string, ZoneKey>();
+  for (const [bucket, ids] of presentByBucket)
+    for (const id of ids) bucketOf.set(id, bucket);
+
+  // Release slots for sessions that left or changed column.
+  for (const [sid, a] of [...slotAlloc]) {
+    if (bucketOf.get(sid) !== a.bucket) slotAlloc.delete(sid);
+  }
+
+  const result = new Map<string, number>();
+  for (const [bucket, ids] of presentByBucket) {
+    const used = new Set<number>();
+    for (const id of ids) {
+      const a = slotAlloc.get(id);
+      if (a) used.add(a.slot);
+    }
+    // Sorted so simultaneous newcomers get deterministic slots.
+    for (const id of [...ids].sort()) {
+      let a = slotAlloc.get(id);
+      if (!a) {
+        let slot = 0;
+        while (used.has(slot)) slot++;
+        used.add(slot);
+        a = { bucket, slot };
+        slotAlloc.set(id, a);
+      }
+      result.set(id, a.slot);
+    }
+  }
+  return result;
+}
+
+/**
+ * Combine the live `/ws/overview` entries with recently-ended sessions from the
+ * polled session list, join project labels, and assign each peer to a zone slot.
+ *
+ * Bucketing rules:
+ * - A session the list marks "ended" goes to the Ended zone regardless of any
+ *   stale in-memory boss state.
+ * - Otherwise the live bucket from the overview feed wins.
+ * - Recently-ended sessions with no live entry still appear in the Ended zone.
+ */
+export function useCommandCenterPeers(sessions: Session[]): CommandCenterPeers {
+  const entries = useOverviewStore(selectOverviewEntries);
+
+  // Ticking clock (kept out of render for purity) used to age out ended peers.
+  // setState only fires from timer callbacks, never synchronously in render.
+  const [now, setNow] = useState(0);
+  useEffect(() => {
+    const id0 = setTimeout(() => setNow(Date.now()), 0);
+    const id = setInterval(() => setNow(Date.now()), 30000);
+    return () => {
+      clearTimeout(id0);
+      clearInterval(id);
+    };
+  }, []);
+
+  return useMemo(() => {
+    const sessionById = new Map(sessions.map((s) => [s.id, s]));
+
+    // Bucketed, pre-slot peers (without position yet).
+    type Raw = Omit<CommandPeer, "slotIndex" | "position">;
+    const byZone: Record<ZoneKey, Raw[]> = {
+      needs_you: [],
+      working: [],
+      done: [],
+      ended: [],
+    };
+    const seen = new Set<string>();
+
+    // 1) Live entries from the overview feed.
+    for (const e of entries) {
+      const session = sessionById.get(e.sessionId);
+      // The backend marks finished sessions "completed" (not "active").
+      const bucket: ZoneKey =
+        session && session.status !== "active" ? "ended" : e.bucket;
+      seen.add(e.sessionId);
+      byZone[bucket].push({
+        sessionId: e.sessionId,
+        label: labelFor(session, e.sessionId),
+        bucket,
+        state: e.state,
+        currentTask: e.currentTask ?? null,
+        todoDone: e.todoDone ?? 0,
+        todoTotal: e.todoTotal ?? 0,
+        subagentCount: e.subagentCount ?? 0,
+      });
+    }
+
+    // 2) Recently-finished sessions with no live entry.
+    for (const s of sessions) {
+      if (seen.has(s.id)) continue;
+      if (s.status === "active") continue; // only finished sessions exit
+      const endedAt = new Date(s.updatedAt).getTime();
+      if (Number.isNaN(endedAt) || now - endedAt > RECENT_ENDED_MS) continue;
+      byZone.ended.push({
+        sessionId: s.id,
+        label: labelFor(s, s.id),
+        bucket: "ended",
+        state: null,
+        currentTask: null,
+        todoDone: 0,
+        todoTotal: 0,
+        subagentCount: 0,
+      });
+    }
+
+    // 3) Free-slot allocation: each session keeps whatever slot it claimed
+    //    (lowest free) until it leaves/changes column — no reshuffling.
+    const presentByBucket = new Map<ZoneKey, string[]>();
+    for (const key of ZONE_ORDER)
+      presentByBucket.set(
+        key,
+        byZone[key].map((r) => r.sessionId),
+      );
+    const slots = assignSlots(presentByBucket);
+
+    const peers: CommandPeer[] = [];
+    const counts = {} as Record<ZoneKey, number>;
+    const overflow = {} as Record<ZoneKey, number>;
+    for (const key of ZONE_ORDER) {
+      const zone = ZONE_BY_KEY[key];
+      const raws = byZone[key];
+      counts[key] = raws.length;
+      let overflowCount = 0;
+      for (const raw of raws) {
+        const slot = slots.get(raw.sessionId) ?? 0;
+        if (slot >= MAX_SLOTS) {
+          overflowCount++;
+          continue;
+        }
+        peers.push({
+          ...raw,
+          slotIndex: slot,
+          position: slotPosition(zone, slot),
+        });
+      }
+      overflow[key] = overflowCount;
+    }
+
+    // Combined cross-session totals (active terminals only).
+    const summary: CommandSummary = {
+      terminals: counts.needs_you + counts.working + counts.done,
+      subagents: 0,
+      todoDone: 0,
+      todoTotal: 0,
+    };
+    for (const key of ["needs_you", "working", "done"] as const) {
+      for (const raw of byZone[key]) {
+        summary.subagents += raw.subagentCount;
+        summary.todoDone += raw.todoDone;
+        summary.todoTotal += raw.todoTotal;
+      }
+    }
+
+    return { peers, counts, overflow, summary };
+  }, [entries, sessions, now]);
+}

--- a/frontend/src/components/command/useCommandCenterPeers.ts
+++ b/frontend/src/components/command/useCommandCenterPeers.ts
@@ -66,6 +66,11 @@ function labelFor(session: Session | undefined, sessionId: string): string {
 // ---------------------------------------------------------------------------
 const slotAlloc = new Map<string, { bucket: ZoneKey; slot: number }>();
 
+/** Clear all slot reservations (call on Command Center unmount). */
+export function resetSlotAlloc(): void {
+  slotAlloc.clear();
+}
+
 function assignSlots(
   presentByBucket: Map<ZoneKey, string[]>,
 ): Map<string, number> {

--- a/frontend/src/components/command/useCommandCenterPeers.ts
+++ b/frontend/src/components/command/useCommandCenterPeers.ts
@@ -1,7 +1,10 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
-import { useOverviewStore, selectOverviewEntries } from "@/stores/overviewStore";
+import {
+  useOverviewStore,
+  selectOverviewEntries,
+} from "@/stores/overviewStore";
 import type { BossState, Position } from "@/types";
 import type { Session } from "@/hooks/useSessions";
 import {
@@ -112,15 +115,12 @@ export function useCommandCenterPeers(sessions: Session[]): CommandCenterPeers {
   const entries = useOverviewStore(selectOverviewEntries);
 
   // Ticking clock (kept out of render for purity) used to age out ended peers.
-  // setState only fires from timer callbacks, never synchronously in render.
-  const [now, setNow] = useState(0);
+  // Initialized to the current time so the first render correctly ages out old
+  // ended sessions; the interval keeps it fresh thereafter.
+  const [now, setNow] = useState(() => Date.now());
   useEffect(() => {
-    const id0 = setTimeout(() => setNow(Date.now()), 0);
     const id = setInterval(() => setNow(Date.now()), 30000);
-    return () => {
-      clearTimeout(id0);
-      clearInterval(id);
-    };
+    return () => clearInterval(id);
   }, []);
 
   return useMemo(() => {

--- a/frontend/src/components/game/EmployeeOfTheMonth.tsx
+++ b/frontend/src/components/game/EmployeeOfTheMonth.tsx
@@ -13,11 +13,14 @@ export function EmployeeOfTheMonth(): ReactNode {
   const [photoTexture, setPhotoTexture] = useState<Texture | null>(null);
 
   useEffect(() => {
-    Assets.load("/sprites/employee-of-month.png")
+    const assetPath = "/sprites/employee-of-month.png";
+    Assets.load(assetPath)
       .then((texture) => {
         setPhotoTexture(texture as Texture);
       })
-      .catch(() => {});
+      .catch((err) => {
+        console.warn(`[EmployeeOfTheMonth] Failed to load ${assetPath}:`, err);
+      });
   }, []);
 
   const drawFrame = useCallback((g: Graphics) => {

--- a/frontend/src/components/game/MarqueeText.tsx
+++ b/frontend/src/components/game/MarqueeText.tsx
@@ -125,10 +125,18 @@ export function MarqueeText({
     setMaskGraphics(ref);
   }, []);
 
-  // Callback ref for text container
-  const textContainerRefCallback = useCallback((ref: Container | null) => {
-    textContainerRef.current = ref;
-  }, []);
+  // Callback ref for text container. Reapply the mask here too, so clipping
+  // survives the container instance being recreated while maskGraphics is stable
+  // (the [maskGraphics]-only effect above wouldn't re-run in that case).
+  const textContainerRefCallback = useCallback(
+    (ref: Container | null) => {
+      textContainerRef.current = ref;
+      if (ref && maskGraphics) {
+        ref.mask = maskGraphics;
+      }
+    },
+    [maskGraphics],
+  );
 
   return (
     <pixiContainer>

--- a/frontend/src/components/layout/HeaderControls.tsx
+++ b/frontend/src/components/layout/HeaderControls.tsx
@@ -1,21 +1,10 @@
 "use client";
 
-import {
-  Activity,
-  Play,
-  RefreshCw,
-  Bug,
-  Trash2,
-  HelpCircle,
-  Settings,
-  Map,
-  Bell,
-  LayoutGrid,
-} from "lucide-react";
+import { Activity, HelpCircle, Settings, Bell, LayoutGrid } from "lucide-react";
 import { useTranslation } from "@/hooks/useTranslation";
 import { useNavigationStore } from "@/stores/navigationStore";
-import { useTourStore } from "@/stores/tourStore";
 import { useAttentionStore, selectUnreadCount } from "@/stores/attentionStore";
+import { HeaderMoreMenu } from "@/components/layout/HeaderMoreMenu";
 
 // ============================================================================
 // TYPES
@@ -40,8 +29,10 @@ interface HeaderControlsProps {
 // ============================================================================
 
 /**
- * Desktop-only header controls: action buttons (Simulate, Reset, Clear DB,
- * Debug, Settings, Help) and the connection/AI status display.
+ * Desktop-only header controls. Frequently-used entry points (Command Center,
+ * Settings, Help, attention queue) stay visible; the rarely-used
+ * developer/maintenance actions live in the "⋯" overflow menu, and the tour
+ * moved into the Help modal — keeping the header readable.
  *
  * Hidden on mobile — the MobileDrawer handles those actions instead.
  */
@@ -60,53 +51,11 @@ export function HeaderControls({
   const { t } = useTranslation();
   const view = useNavigationStore((s) => s.view);
   const goToCommand = useNavigationStore((s) => s.goToCommand);
-  const buildingConfig = useNavigationStore((s) => s.buildingConfig);
-  const hasSeenTour = useTourStore((s) => s.hasSeenTour);
-  const startTour = useTourStore((s) => s.startTour); // (mode: "single" | "building") => void
   const unreadCount = useAttentionStore(selectUnreadCount);
   const openCommandBar = useAttentionStore((s) => s.openCommandBar);
-  const hasBuildingConfig =
-    buildingConfig !== null && (buildingConfig?.floors.length ?? 0) > 0;
 
   return (
-    <div className="flex gap-4 items-center">
-      <button
-        onClick={onSimulate}
-        data-tour-id="simulate-btn"
-        className="flex items-center gap-2 px-3 py-1.5 bg-emerald-500/10 hover:bg-emerald-500/20 text-emerald-500 border border-emerald-500/30 rounded text-xs font-bold transition-colors"
-      >
-        <Play size={14} fill="currentColor" />
-        {t("header.simulate")}
-      </button>
-
-      <button
-        onClick={onReset}
-        className="flex items-center gap-2 px-3 py-1.5 bg-amber-500/10 hover:bg-amber-500/20 text-amber-500 border border-amber-500/30 rounded text-xs font-bold transition-colors"
-      >
-        <RefreshCw size={14} />
-        {t("header.reset")}
-      </button>
-
-      <button
-        onClick={onClearDB}
-        className="flex items-center gap-2 px-3 py-1.5 bg-rose-500/10 hover:bg-rose-500/20 text-rose-500 border border-rose-500/30 rounded text-xs font-bold transition-colors"
-      >
-        <Trash2 size={14} />
-        {t("header.clearDb")}
-      </button>
-
-      <button
-        onClick={onToggleDebug}
-        className={`flex items-center gap-2 px-3 py-1.5 border rounded text-xs font-bold transition-colors ${
-          debugMode
-            ? "bg-green-500/20 text-green-400 border-green-500/30"
-            : "bg-slate-500/10 text-slate-400 border-slate-500/30 hover:bg-slate-500/20"
-        }`}
-      >
-        <Bug size={14} />
-        {debugMode ? t("header.debugOn") : t("header.debugOff")}
-      </button>
-
+    <div className="flex gap-3 items-center">
       {unreadCount > 0 && (
         <button
           onClick={openCommandBar}
@@ -117,21 +66,6 @@ export function HeaderControls({
           <span className="absolute -top-1 -right-1 bg-orange-500 text-white text-[9px] font-bold rounded-full w-4 h-4 flex items-center justify-center">
             {unreadCount > 9 ? "9+" : unreadCount}
           </span>
-        </button>
-      )}
-
-      {/* Tour button */}
-      {!hasSeenTour && (
-        <button
-          onClick={() => {
-            const mode =
-              view !== "single" && hasBuildingConfig ? "building" : "single";
-            startTour(mode);
-          }}
-          className="flex items-center gap-2 px-3 py-1.5 bg-orange-500/10 hover:bg-orange-500/20 text-orange-500 border border-orange-500/30 rounded text-xs font-bold transition-colors"
-        >
-          <Map size={14} />
-          {t("header.tour")}
         </button>
       )}
 
@@ -167,6 +101,15 @@ export function HeaderControls({
         <HelpCircle size={14} />
         {t("header.help")}
       </button>
+
+      {/* Rarely-used developer/maintenance actions */}
+      <HeaderMoreMenu
+        debugMode={debugMode}
+        onSimulate={onSimulate}
+        onReset={onReset}
+        onClearDB={onClearDB}
+        onToggleDebug={onToggleDebug}
+      />
 
       {/* Connection and AI status */}
       <div className="flex flex-col items-end border-l border-slate-800 pl-4">

--- a/frontend/src/components/layout/HeaderControls.tsx
+++ b/frontend/src/components/layout/HeaderControls.tsx
@@ -10,6 +10,7 @@ import {
   Settings,
   Map,
   Bell,
+  LayoutGrid,
 } from "lucide-react";
 import { useTranslation } from "@/hooks/useTranslation";
 import { useNavigationStore } from "@/stores/navigationStore";
@@ -24,6 +25,8 @@ interface HeaderControlsProps {
   isConnected: boolean;
   debugMode: boolean;
   aiSummaryEnabled: boolean | null;
+  /** Number of active sessions — gates the Command Center button (>= 2). */
+  activeSessionCount: number;
   onSimulate: () => Promise<void>;
   onReset: () => void;
   onClearDB: () => void;
@@ -46,6 +49,7 @@ export function HeaderControls({
   isConnected,
   debugMode,
   aiSummaryEnabled,
+  activeSessionCount,
   onSimulate,
   onReset,
   onClearDB,
@@ -55,6 +59,7 @@ export function HeaderControls({
 }: HeaderControlsProps): React.ReactNode {
   const { t } = useTranslation();
   const view = useNavigationStore((s) => s.view);
+  const goToCommand = useNavigationStore((s) => s.goToCommand);
   const buildingConfig = useNavigationStore((s) => s.buildingConfig);
   const hasSeenTour = useTourStore((s) => s.hasSeenTour);
   const startTour = useTourStore((s) => s.startTour); // (mode: "single" | "building") => void
@@ -127,6 +132,22 @@ export function HeaderControls({
         >
           <Map size={14} />
           {t("header.tour")}
+        </button>
+      )}
+
+      {/* Command Center — cross-terminal overview (>= 2 active sessions) */}
+      {activeSessionCount >= 2 && (
+        <button
+          onClick={goToCommand}
+          title={t("commandCenter.title")}
+          className={`flex items-center gap-2 px-3 py-1.5 border rounded text-xs font-bold transition-colors ${
+            view === "command"
+              ? "bg-sky-500/20 text-sky-400 border-sky-500/30"
+              : "bg-sky-500/10 text-sky-500 border-sky-500/30 hover:bg-sky-500/20"
+          }`}
+        >
+          <LayoutGrid size={14} />
+          {t("header.commandCenter")}
         </button>
       )}
 

--- a/frontend/src/components/layout/HeaderMoreMenu.tsx
+++ b/frontend/src/components/layout/HeaderMoreMenu.tsx
@@ -1,0 +1,138 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { MoreHorizontal, Play, RefreshCw, Trash2, Bug } from "lucide-react";
+import { useTranslation } from "@/hooks/useTranslation";
+
+// ============================================================================
+// TYPES
+// ============================================================================
+
+interface HeaderMoreMenuProps {
+  debugMode: boolean;
+  onSimulate: () => Promise<void>;
+  onReset: () => void;
+  onClearDB: () => void;
+  onToggleDebug: () => void;
+}
+
+// ============================================================================
+// COMPONENT
+// ============================================================================
+
+/**
+ * Overflow "⋯" menu holding the rarely-used developer/maintenance actions
+ * (Simulate, Reset, Clear DB, Debug) so they don't crowd the header.
+ * Closes on outside click or Escape.
+ */
+export function HeaderMoreMenu({
+  debugMode,
+  onSimulate,
+  onReset,
+  onClearDB,
+  onToggleDebug,
+}: HeaderMoreMenuProps): React.ReactNode {
+  const { t } = useTranslation();
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const onPointerDown = (e: MouseEvent): void => {
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    const onKeyDown = (e: KeyboardEvent): void => {
+      if (e.key === "Escape") setOpen(false);
+    };
+    document.addEventListener("mousedown", onPointerDown);
+    document.addEventListener("keydown", onKeyDown);
+    return () => {
+      document.removeEventListener("mousedown", onPointerDown);
+      document.removeEventListener("keydown", onKeyDown);
+    };
+  }, [open]);
+
+  const itemClass =
+    "flex w-full items-center gap-2 px-3 py-2 text-xs font-bold rounded transition-colors text-left";
+
+  return (
+    <div ref={ref} className="relative">
+      <button
+        onClick={() => setOpen((v) => !v)}
+        aria-haspopup="menu"
+        aria-expanded={open}
+        aria-label={t("header.moreMenu")}
+        title={t("header.more")}
+        className={`flex items-center gap-2 px-3 py-1.5 border rounded text-xs font-bold transition-colors ${
+          open
+            ? "bg-slate-700 text-white border-slate-600"
+            : "bg-slate-500/10 text-slate-400 border-slate-500/30 hover:bg-slate-500/20"
+        }`}
+      >
+        <MoreHorizontal size={14} />
+        {t("header.more")}
+      </button>
+
+      {open && (
+        <div
+          role="menu"
+          className="absolute right-0 top-full mt-1 z-50 min-w-[11rem] p-1 bg-slate-900 border border-slate-700 rounded-lg shadow-xl"
+        >
+          <button
+            role="menuitem"
+            onClick={() => {
+              setOpen(false);
+              void onSimulate();
+            }}
+            className={`${itemClass} text-emerald-400 hover:bg-emerald-500/15`}
+          >
+            <Play size={14} fill="currentColor" />
+            {t("header.simulate")}
+          </button>
+
+          <button
+            role="menuitem"
+            onClick={() => {
+              setOpen(false);
+              onReset();
+            }}
+            className={`${itemClass} text-amber-400 hover:bg-amber-500/15`}
+          >
+            <RefreshCw size={14} />
+            {t("header.reset")}
+          </button>
+
+          <button
+            role="menuitem"
+            onClick={() => {
+              setOpen(false);
+              onClearDB();
+            }}
+            className={`${itemClass} text-rose-400 hover:bg-rose-500/15`}
+          >
+            <Trash2 size={14} />
+            {t("header.clearDb")}
+          </button>
+
+          <button
+            role="menuitem"
+            onClick={() => {
+              setOpen(false);
+              onToggleDebug();
+            }}
+            className={`${itemClass} ${
+              debugMode
+                ? "text-green-400 hover:bg-green-500/15"
+                : "text-slate-400 hover:bg-slate-500/15"
+            }`}
+          >
+            <Bug size={14} />
+            {debugMode ? t("header.debugOn") : t("header.debugOff")}
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/layout/StatusToast.tsx
+++ b/frontend/src/components/layout/StatusToast.tsx
@@ -20,8 +20,9 @@ interface StatusToastProps {
 // ============================================================================
 
 /**
- * Displays a transient status message toast in the header, centered between
- * the title and the controls. Renders nothing when message is null.
+ * Displays a transient status message toast, pinned to the bottom-center of
+ * the screen so it never overlaps the header. Renders nothing when message is
+ * null.
  */
 export function StatusToast({ message }: StatusToastProps): React.ReactNode {
   if (!message) return null;
@@ -29,7 +30,7 @@ export function StatusToast({ message }: StatusToastProps): React.ReactNode {
   return (
     <div
       role="status"
-      className={`px-4 py-1.5 rounded-full border shadow-lg flex items-center gap-3 text-[11px] font-bold tracking-wide uppercase whitespace-nowrap animate-in slide-in-from-top-2 duration-300
+      className={`px-4 py-1.5 rounded-full border shadow-lg flex items-center gap-3 text-[11px] font-bold tracking-wide uppercase whitespace-nowrap animate-in slide-in-from-bottom-2 duration-300
         ${
           message.type === "success"
             ? "bg-emerald-500/10 border-emerald-500/20 text-emerald-400"

--- a/frontend/src/components/navigation/Breadcrumb.tsx
+++ b/frontend/src/components/navigation/Breadcrumb.tsx
@@ -15,9 +15,15 @@ export function Breadcrumb(): React.ReactNode {
   const goToBuilding = useNavigationStore((s) => s.goToBuilding);
   const { t } = useTranslation();
 
-  // Only show when in building or floor view
+  // Hidden in the single office view.
   if (view === "single") return null;
 
+  const hasBuilding = (buildingConfig?.floors.length ?? 0) > 0;
+  // In the Command Center, only show the crumb when there's a building to
+  // return to (otherwise the header COMMAND button is the only entry point).
+  if (view === "command" && !hasBuilding) return null;
+
+  const isCommand = view === "command";
   const isLobby = floorId === LOBBY_FLOOR_ID;
   const floor = isLobby
     ? null
@@ -45,6 +51,16 @@ export function Breadcrumb(): React.ReactNode {
         <span>{"\u{1F3E2}"}</span>
         <span>{buildingConfig?.buildingName ?? t("navigation.building")}</span>
       </button>
+
+      {isCommand && (
+        <>
+          <span className="text-slate-600">/</span>
+          <span className="flex items-center gap-1 px-2 py-0.5 rounded text-white bg-slate-800">
+            <span>{"\u{1F6F0}\u{FE0F}"}</span>
+            <span>{t("commandCenter.title")}</span>
+          </span>
+        </>
+      )}
 
       {isLobby && (
         <>

--- a/frontend/src/components/overlay/SettingsModal.tsx
+++ b/frontend/src/components/overlay/SettingsModal.tsx
@@ -79,8 +79,9 @@ export default function SettingsModal({
   const [activeTab, setActiveTab] = useState<SettingsTab>(initialTab);
   const [buildingDirty, setBuildingDirty] = useState(false);
 
-  // Sync tab when initialTab changes (e.g. edit-building request)
+  // Sync tab when initialTab changes (e.g. edit-building request).
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- syncing the controlled initialTab prop into local tab state
     setActiveTab(initialTab);
   }, [initialTab]);
 

--- a/frontend/src/components/overlay/SettingsModal.tsx
+++ b/frontend/src/components/overlay/SettingsModal.tsx
@@ -81,7 +81,6 @@ export default function SettingsModal({
 
   // Sync tab when initialTab changes (e.g. edit-building request).
   useEffect(() => {
-    // eslint-disable-next-line react-hooks/set-state-in-effect -- syncing the controlled initialTab prop into local tab state
     setActiveTab(initialTab);
   }, [initialTab]);
 

--- a/frontend/src/components/settings/BuildingTab.tsx
+++ b/frontend/src/components/settings/BuildingTab.tsx
@@ -157,7 +157,8 @@ export function BuildingTab({
     floors: FloorFormData[];
   } | null>(null);
 
-  // Initialize form from store config
+  // Initialize form from store config.
+  /* eslint-disable react-hooks/set-state-in-effect -- seeding form state from the loaded building config */
   useEffect(() => {
     if (buildingConfig) {
       const name = buildingConfig.buildingName;
@@ -167,6 +168,7 @@ export function BuildingTab({
       setInitialData({ buildingName: name, floors: fl });
     }
   }, [buildingConfig]);
+  /* eslint-enable react-hooks/set-state-in-effect */
 
   // Detect dirty state
   useEffect(() => {

--- a/frontend/src/components/settings/BuildingTab.tsx
+++ b/frontend/src/components/settings/BuildingTab.tsx
@@ -158,7 +158,6 @@ export function BuildingTab({
   } | null>(null);
 
   // Initialize form from store config.
-  /* eslint-disable react-hooks/set-state-in-effect -- seeding form state from the loaded building config */
   useEffect(() => {
     if (buildingConfig) {
       const name = buildingConfig.buildingName;
@@ -168,7 +167,6 @@ export function BuildingTab({
       setInitialData({ buildingName: name, floors: fl });
     }
   }, [buildingConfig]);
-  /* eslint-enable react-hooks/set-state-in-effect */
 
   // Detect dirty state
   useEffect(() => {

--- a/frontend/src/components/settings/BuildingTab.tsx
+++ b/frontend/src/components/settings/BuildingTab.tsx
@@ -242,10 +242,15 @@ export function BuildingTab({
         setSaved(true);
         setTimeout(() => setSaved(false), 2000);
       } else {
-        setSaveError(`Save failed: ${res.status} ${res.statusText}`);
+        setSaveError(
+          t("settings.building.saveFailed", {
+            status: res.status,
+            statusText: res.statusText,
+          }),
+        );
       }
     } catch {
-      setSaveError("Cannot reach backend — is the server running?");
+      setSaveError(t("settings.building.saveUnreachable"));
     } finally {
       setSaving(false);
     }

--- a/frontend/src/components/views/BuildingView.tsx
+++ b/frontend/src/components/views/BuildingView.tsx
@@ -2,9 +2,11 @@
 
 import { useMemo } from "react";
 import { useNavigationStore } from "@/stores/navigationStore";
+import { useTranslation } from "@/hooks/useTranslation";
 import { LOBBY_FLOOR_ID } from "@/types/navigation";
 import type { FloorConfig } from "@/types/navigation";
 import type { Session } from "@/hooks/useSessions";
+import { sessionMatchesFloor } from "@/components/command/sessionMatchesFloor";
 
 // ============================================================================
 // FLOOR ROW
@@ -70,18 +72,6 @@ function FloorRow({
 // MATCHING HELPERS
 // ============================================================================
 
-/** Check if a session belongs to a specific floor's rooms. */
-function sessionMatchesFloor(session: Session, floor: FloorConfig): boolean {
-  return floor.rooms.some((room) => {
-    if (!room.repoName) return false;
-    if (session.projectRoot) {
-      const basename = session.projectRoot.split("/").pop();
-      if (basename === room.repoName) return true;
-    }
-    return session.projectName === room.repoName;
-  });
-}
-
 /** Check if a session belongs to ANY floor. */
 function sessionMatchesAnyFloor(
   session: Session,
@@ -99,6 +89,7 @@ export interface BuildingViewProps {
 }
 
 export function BuildingView({ sessions }: BuildingViewProps): React.ReactNode {
+  const { t } = useTranslation();
   const buildingConfig = useNavigationStore((s) => s.buildingConfig);
   const goToFloor = useNavigationStore((s) => s.goToFloor);
   const goToCommand = useNavigationStore((s) => s.goToCommand);
@@ -135,123 +126,123 @@ export function BuildingView({ sessions }: BuildingViewProps): React.ReactNode {
       <div className="m-auto w-full max-w-2xl flex flex-col">
         {/* Building header */}
         <div className="text-center mb-8">
-        <h2 className="text-3xl font-bold text-white tracking-tight mb-1">
-          {buildingConfig.buildingName}
-        </h2>
-        <div className="flex items-center justify-center gap-3">
-          <p className="text-sm text-slate-500 font-mono">
-            {buildingConfig.floors.length} floor
-            {buildingConfig.floors.length !== 1 ? "s" : ""}
-          </p>
-          <button
-            type="button"
-            onClick={requestEditBuilding}
-            className="text-xs text-slate-500 hover:text-purple-400 font-mono px-2 py-0.5 border border-slate-700 hover:border-purple-500 rounded transition-colors"
-          >
-            Edit
-          </button>
+          <h2 className="text-3xl font-bold text-white tracking-tight mb-1">
+            {buildingConfig.buildingName}
+          </h2>
+          <div className="flex items-center justify-center gap-3">
+            <p className="text-sm text-slate-500 font-mono">
+              {buildingConfig.floors.length} floor
+              {buildingConfig.floors.length !== 1 ? "s" : ""}
+            </p>
+            <button
+              type="button"
+              onClick={requestEditBuilding}
+              className="text-xs text-slate-500 hover:text-purple-400 font-mono px-2 py-0.5 border border-slate-700 hover:border-purple-500 rounded transition-colors"
+            >
+              Edit
+            </button>
+          </div>
         </div>
-      </div>
 
-      {/* Building cross-section */}
-      <div className="w-full max-w-2xl flex flex-col gap-2">
-        {/* Roof */}
-        <div className="h-2 bg-slate-800 rounded-t-lg mx-4" />
+        {/* Building cross-section */}
+        <div className="w-full max-w-2xl flex flex-col gap-2">
+          {/* Roof */}
+          <div className="h-2 bg-slate-800 rounded-t-lg mx-4" />
 
-        {/* Command Center — penthouse tile gathering every terminal's boss */}
-        <button
-          onClick={(e) => {
-            useNavigationStore
-              .getState()
-              .setTransitionOrigin({ x: e.clientX, y: e.clientY });
-            goToCommand();
-          }}
-          data-tour-id="command-center-tile"
-          className="group flex items-stretch w-full rounded-lg border border-sky-700/60 bg-sky-950/40 hover:border-sky-500 hover:bg-sky-900/40 transition-all duration-200"
-        >
-          {/* Badge */}
-          <div className="flex items-center justify-center w-16 rounded-l-lg text-2xl">
-            {"\u{1F6F0}\u{FE0F}"}
-          </div>
-
-          {/* Info */}
-          <div className="flex-grow flex items-center gap-4 px-5 py-3">
-            <div className="flex flex-col items-start">
-              <span className="text-sm font-bold text-sky-300 group-hover:text-sky-200 transition-colors">
-                Command Center
-              </span>
-              <span className="text-xs text-slate-500 font-mono">
-                {activeSessionCount > 0
-                  ? `${activeSessionCount} active terminal${activeSessionCount !== 1 ? "s" : ""}`
-                  : "Overview of every terminal"}
-              </span>
+          {/* Command Center — penthouse tile gathering every terminal's boss */}
+          <button
+            onClick={(e) => {
+              useNavigationStore
+                .getState()
+                .setTransitionOrigin({ x: e.clientX, y: e.clientY });
+              goToCommand();
+            }}
+            data-tour-id="command-center-tile"
+            className="group flex items-stretch w-full rounded-lg border border-sky-700/60 bg-sky-950/40 hover:border-sky-500 hover:bg-sky-900/40 transition-all duration-200"
+          >
+            {/* Badge */}
+            <div className="flex items-center justify-center w-16 rounded-l-lg text-2xl">
+              {"\u{1F6F0}\u{FE0F}"}
             </div>
-          </div>
 
-          {/* Arrow */}
-          <div className="flex items-center px-4 text-sky-700 group-hover:text-sky-400 transition-colors">
-            &rarr;
-          </div>
-        </button>
-
-        {/* Floors sorted top-down by floor number (highest first) */}
-        {sortedFloors.map((floor) => {
-          const floorSessions = sessions.filter((s) =>
-            sessionMatchesFloor(s, floor),
-          );
-          return (
-            <FloorRow
-              key={floor.id}
-              floor={floor}
-              activeSessionCount={
-                floorSessions.filter((s) => s.status === "active").length
-              }
-              onClick={(origin) => {
-                useNavigationStore.getState().setTransitionOrigin(origin);
-                goToFloor(floor.id);
-              }}
-            />
-          );
-        })}
-
-        {/* Lobby / Ground — click to view unmatched sessions */}
-        <button
-          onClick={(e) => {
-            useNavigationStore.getState().setTransitionOrigin({
-              x: e.clientX,
-              y: e.clientY,
-            });
-            goToFloor(LOBBY_FLOOR_ID);
-          }}
-          className="group flex items-stretch w-full rounded-lg border border-dashed border-slate-800 hover:border-slate-600 bg-slate-900/30 hover:bg-slate-900/60 transition-all duration-200"
-        >
-          {/* Badge */}
-          <div className="flex items-center justify-center w-16 rounded-l-lg text-2xl">
-            {"\u{1F6AA}"}
-          </div>
-
-          {/* Info */}
-          <div className="flex-grow flex items-center gap-4 px-5 py-3">
-            <div className="flex flex-col items-start">
-              <span className="text-sm text-slate-400 font-bold group-hover:text-slate-300 transition-colors">
-                Lobby
-              </span>
-              <span className="text-xs text-slate-600 font-mono">
-                {unmatchedSessions.length > 0
-                  ? `${unmatchedSessions.length} active unassigned`
-                  : "All sessions assigned"}
-              </span>
+            {/* Info */}
+            <div className="flex-grow flex items-center gap-4 px-5 py-3">
+              <div className="flex flex-col items-start">
+                <span className="text-sm font-bold text-sky-300 group-hover:text-sky-200 transition-colors">
+                  {t("commandCenter.title")}
+                </span>
+                <span className="text-xs text-slate-500 font-mono">
+                  {activeSessionCount > 0
+                    ? `${activeSessionCount} active terminal${activeSessionCount !== 1 ? "s" : ""}`
+                    : "Overview of every terminal"}
+                </span>
+              </div>
             </div>
-          </div>
 
-          {/* Arrow */}
-          <div className="flex items-center px-4 text-slate-700 group-hover:text-slate-500 transition-colors">
-            &rarr;
-          </div>
-        </button>
+            {/* Arrow */}
+            <div className="flex items-center px-4 text-sky-700 group-hover:text-sky-400 transition-colors">
+              &rarr;
+            </div>
+          </button>
 
-        {/* Foundation */}
-        <div className="h-2 bg-slate-800 rounded-b-lg mx-4" />
+          {/* Floors sorted top-down by floor number (highest first) */}
+          {sortedFloors.map((floor) => {
+            const floorSessions = sessions.filter((s) =>
+              sessionMatchesFloor(s, floor),
+            );
+            return (
+              <FloorRow
+                key={floor.id}
+                floor={floor}
+                activeSessionCount={
+                  floorSessions.filter((s) => s.status === "active").length
+                }
+                onClick={(origin) => {
+                  useNavigationStore.getState().setTransitionOrigin(origin);
+                  goToFloor(floor.id);
+                }}
+              />
+            );
+          })}
+
+          {/* Lobby / Ground — click to view unmatched sessions */}
+          <button
+            onClick={(e) => {
+              useNavigationStore.getState().setTransitionOrigin({
+                x: e.clientX,
+                y: e.clientY,
+              });
+              goToFloor(LOBBY_FLOOR_ID);
+            }}
+            className="group flex items-stretch w-full rounded-lg border border-dashed border-slate-800 hover:border-slate-600 bg-slate-900/30 hover:bg-slate-900/60 transition-all duration-200"
+          >
+            {/* Badge */}
+            <div className="flex items-center justify-center w-16 rounded-l-lg text-2xl">
+              {"\u{1F6AA}"}
+            </div>
+
+            {/* Info */}
+            <div className="flex-grow flex items-center gap-4 px-5 py-3">
+              <div className="flex flex-col items-start">
+                <span className="text-sm text-slate-400 font-bold group-hover:text-slate-300 transition-colors">
+                  Lobby
+                </span>
+                <span className="text-xs text-slate-600 font-mono">
+                  {unmatchedSessions.length > 0
+                    ? `${unmatchedSessions.length} active unassigned`
+                    : "All sessions assigned"}
+                </span>
+              </div>
+            </div>
+
+            {/* Arrow */}
+            <div className="flex items-center px-4 text-slate-700 group-hover:text-slate-500 transition-colors">
+              &rarr;
+            </div>
+          </button>
+
+          {/* Foundation */}
+          <div className="h-2 bg-slate-800 rounded-b-lg mx-4" />
         </div>
       </div>
     </div>

--- a/frontend/src/components/views/BuildingView.tsx
+++ b/frontend/src/components/views/BuildingView.tsx
@@ -101,7 +101,13 @@ export interface BuildingViewProps {
 export function BuildingView({ sessions }: BuildingViewProps): React.ReactNode {
   const buildingConfig = useNavigationStore((s) => s.buildingConfig);
   const goToFloor = useNavigationStore((s) => s.goToFloor);
+  const goToCommand = useNavigationStore((s) => s.goToCommand);
   const requestEditBuilding = useNavigationStore((s) => s.requestEditBuilding);
+
+  // Active sessions across the whole building feed the Command Center tile.
+  const activeSessionCount = sessions.filter(
+    (s) => s.status === "active",
+  ).length;
 
   // Active sessions that don't match any floor
   const unmatchedSessions = useMemo(
@@ -123,9 +129,12 @@ export function BuildingView({ sessions }: BuildingViewProps): React.ReactNode {
   );
 
   return (
-    <div className="flex flex-col items-center justify-center h-full p-8">
-      {/* Building header */}
-      <div className="text-center mb-8">
+    <div className="flex flex-col items-center h-full overflow-y-auto p-8">
+      {/* m-auto centres the building when it fits, and lets it scroll when the
+          floor list is taller than the viewport. */}
+      <div className="m-auto w-full max-w-2xl flex flex-col">
+        {/* Building header */}
+        <div className="text-center mb-8">
         <h2 className="text-3xl font-bold text-white tracking-tight mb-1">
           {buildingConfig.buildingName}
         </h2>
@@ -148,6 +157,42 @@ export function BuildingView({ sessions }: BuildingViewProps): React.ReactNode {
       <div className="w-full max-w-2xl flex flex-col gap-2">
         {/* Roof */}
         <div className="h-2 bg-slate-800 rounded-t-lg mx-4" />
+
+        {/* Command Center — penthouse tile gathering every terminal's boss */}
+        <button
+          onClick={(e) => {
+            useNavigationStore
+              .getState()
+              .setTransitionOrigin({ x: e.clientX, y: e.clientY });
+            goToCommand();
+          }}
+          data-tour-id="command-center-tile"
+          className="group flex items-stretch w-full rounded-lg border border-sky-700/60 bg-sky-950/40 hover:border-sky-500 hover:bg-sky-900/40 transition-all duration-200"
+        >
+          {/* Badge */}
+          <div className="flex items-center justify-center w-16 rounded-l-lg text-2xl">
+            {"\u{1F6F0}\u{FE0F}"}
+          </div>
+
+          {/* Info */}
+          <div className="flex-grow flex items-center gap-4 px-5 py-3">
+            <div className="flex flex-col items-start">
+              <span className="text-sm font-bold text-sky-300 group-hover:text-sky-200 transition-colors">
+                Command Center
+              </span>
+              <span className="text-xs text-slate-500 font-mono">
+                {activeSessionCount > 0
+                  ? `${activeSessionCount} active terminal${activeSessionCount !== 1 ? "s" : ""}`
+                  : "Overview of every terminal"}
+              </span>
+            </div>
+          </div>
+
+          {/* Arrow */}
+          <div className="flex items-center px-4 text-sky-700 group-hover:text-sky-400 transition-colors">
+            &rarr;
+          </div>
+        </button>
 
         {/* Floors sorted top-down by floor number (highest first) */}
         {sortedFloors.map((floor) => {
@@ -207,6 +252,7 @@ export function BuildingView({ sessions }: BuildingViewProps): React.ReactNode {
 
         {/* Foundation */}
         <div className="h-2 bg-slate-800 rounded-b-lg mx-4" />
+        </div>
       </div>
     </div>
   );

--- a/frontend/src/hooks/useOfficeTextures.ts
+++ b/frontend/src/hooks/useOfficeTextures.ts
@@ -30,6 +30,7 @@ export interface OfficeTextures {
 
   // Wall items
   wallOutlet: Texture | null;
+  employeeOfMonth: Texture | null;
 
   // Agent accessories
   headset: Texture | null;
@@ -66,6 +67,7 @@ const TEXTURE_PATHS: Record<keyof OfficeTextures, string> = {
   elevatorFrame: "/sprites/elevator_frame.png",
   elevatorDoor: "/sprites/elevator_door.png",
   wallOutlet: "/sprites/wall-outlet.png",
+  employeeOfMonth: "/sprites/employee-of-month.png",
   headset: "/sprites/headset_small.png",
   sunglasses: "/sprites/sunglasses.png",
   coffeeMug: "/sprites/coffee-mug.png",
@@ -93,6 +95,7 @@ const EMPTY_TEXTURES: OfficeTextures = {
   elevatorFrame: null,
   elevatorDoor: null,
   wallOutlet: null,
+  employeeOfMonth: null,
   headset: null,
   sunglasses: null,
   coffeeMug: null,

--- a/frontend/src/hooks/useOverviewWebSocket.ts
+++ b/frontend/src/hooks/useOverviewWebSocket.ts
@@ -1,0 +1,135 @@
+"use client";
+
+import { useCallback, useEffect, useRef } from "react";
+import { useOverviewStore } from "@/stores/overviewStore";
+import type { OverviewEntry } from "@/types";
+
+/**
+ * Connects to the global `/ws/overview` feed that carries one boss snapshot per
+ * live session (the Command Center). Separate from {@link useWebSocketEvents},
+ * which is session-bound. Connects only while {@link enabled} is true (i.e. the
+ * user is viewing the Command Center) and tears down on disable/unmount.
+ *
+ * Mirrors the reconnect / connection-id guard pattern of useWebSocketEvents.
+ */
+export function useOverviewWebSocket({ enabled }: { enabled: boolean }): void {
+  const wsRef = useRef<WebSocket | null>(null);
+  const connectionIdRef = useRef(0);
+  const reconnectTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const retryCountRef = useRef(0);
+  const enabledRef = useRef(enabled);
+  // Holds the latest `connect` so the reconnect timer can call it without a
+  // self-reference (which trips no-use-before-define).
+  const connectRef = useRef<(() => void) | null>(null);
+
+  // Keep refs in sync without touching them during render.
+  useEffect(() => {
+    enabledRef.current = enabled;
+  }, [enabled]);
+
+  const setEntries = useOverviewStore((s) => s.setEntries);
+  const setConnected = useOverviewStore((s) => s.setConnected);
+
+  const connect = useCallback(() => {
+    connectionIdRef.current++;
+    const thisConnectionId = connectionIdRef.current;
+
+    if (wsRef.current) {
+      wsRef.current.close();
+      wsRef.current = null;
+    }
+    if (reconnectTimeoutRef.current) {
+      clearTimeout(reconnectTimeoutRef.current);
+      reconnectTimeoutRef.current = null;
+    }
+
+    const wsUrl =
+      process.env.NEXT_PUBLIC_WS_URL || `ws://${window.location.hostname}:8000`;
+    const ws = new WebSocket(`${wsUrl}/ws/overview`);
+    wsRef.current = ws;
+
+    ws.onopen = () => {
+      if (connectionIdRef.current !== thisConnectionId) {
+        ws.close();
+        return;
+      }
+      retryCountRef.current = 0;
+      setConnected(true);
+    };
+
+    ws.onmessage = (event) => {
+      if (connectionIdRef.current !== thisConnectionId) return;
+      try {
+        const msg = JSON.parse(event.data) as {
+          type?: string;
+          state?: { entries?: OverviewEntry[] };
+        };
+        if (msg.type === "state_update" && msg.state?.entries) {
+          setEntries(msg.state.entries);
+        }
+      } catch {
+        // Ignore malformed frames.
+      }
+    };
+
+    ws.onerror = () => {
+      if (connectionIdRef.current !== thisConnectionId) return;
+      console.warn("[overview WS] connection error — will retry");
+    };
+
+    ws.onclose = () => {
+      if (connectionIdRef.current !== thisConnectionId) return;
+      setConnected(false);
+      if (enabledRef.current) {
+        const delay = Math.min(1000 * Math.pow(2, retryCountRef.current), 30000);
+        retryCountRef.current++;
+        reconnectTimeoutRef.current = setTimeout(() => {
+          reconnectTimeoutRef.current = null;
+          if (enabledRef.current) connectRef.current?.();
+        }, delay);
+      }
+    };
+  }, [setConnected, setEntries]);
+
+  // Expose the latest connect to the reconnect timer.
+  useEffect(() => {
+    connectRef.current = connect;
+  }, [connect]);
+
+  useEffect(() => {
+    if (!enabled) {
+      connectionIdRef.current++; // invalidate any pending handlers
+      if (wsRef.current) {
+        wsRef.current.close();
+        wsRef.current = null;
+      }
+      if (reconnectTimeoutRef.current) {
+        clearTimeout(reconnectTimeoutRef.current);
+        reconnectTimeoutRef.current = null;
+      }
+      setConnected(false);
+      useOverviewStore.getState().clear();
+      return;
+    }
+
+    connect();
+
+    const connectionIdAtSetup = connectionIdRef;
+    return () => {
+      // Invalidate any in-flight handlers so a closing socket doesn't reconnect
+      // after unmount.
+      connectionIdAtSetup.current++;
+      if (wsRef.current) {
+        wsRef.current.close();
+        wsRef.current = null;
+      }
+      if (reconnectTimeoutRef.current) {
+        clearTimeout(reconnectTimeoutRef.current);
+        reconnectTimeoutRef.current = null;
+      }
+      // Don't leave a stale "connected" + old entries behind on unmount.
+      setConnected(false);
+      useOverviewStore.getState().clear();
+    };
+  }, [enabled, connect, setConnected]);
+}

--- a/frontend/src/hooks/useOverviewWebSocket.ts
+++ b/frontend/src/hooks/useOverviewWebSocket.ts
@@ -15,7 +15,9 @@ import type { OverviewEntry } from "@/types";
 export function useOverviewWebSocket({ enabled }: { enabled: boolean }): void {
   const wsRef = useRef<WebSocket | null>(null);
   const connectionIdRef = useRef(0);
-  const reconnectTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const reconnectTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(
+    null,
+  );
   const retryCountRef = useRef(0);
   const enabledRef = useRef(enabled);
   // Holds the latest `connect` so the reconnect timer can call it without a
@@ -43,8 +45,10 @@ export function useOverviewWebSocket({ enabled }: { enabled: boolean }): void {
       reconnectTimeoutRef.current = null;
     }
 
+    const wsScheme = window.location.protocol === "https:" ? "wss" : "ws";
     const wsUrl =
-      process.env.NEXT_PUBLIC_WS_URL || `ws://${window.location.hostname}:8000`;
+      process.env.NEXT_PUBLIC_WS_URL ||
+      `${wsScheme}://${window.location.hostname}:8000`;
     const ws = new WebSocket(`${wsUrl}/ws/overview`);
     wsRef.current = ws;
 
@@ -81,7 +85,10 @@ export function useOverviewWebSocket({ enabled }: { enabled: boolean }): void {
       if (connectionIdRef.current !== thisConnectionId) return;
       setConnected(false);
       if (enabledRef.current) {
-        const delay = Math.min(1000 * Math.pow(2, retryCountRef.current), 30000);
+        const delay = Math.min(
+          1000 * Math.pow(2, retryCountRef.current),
+          30000,
+        );
         retryCountRef.current++;
         reconnectTimeoutRef.current = setTimeout(() => {
           reconnectTimeoutRef.current = null;

--- a/frontend/src/hooks/useOverviewWebSocket.ts
+++ b/frontend/src/hooks/useOverviewWebSocket.ts
@@ -68,8 +68,14 @@ export function useOverviewWebSocket({ enabled }: { enabled: boolean }): void {
           type?: string;
           state?: { entries?: OverviewEntry[] };
         };
-        if (msg.type === "state_update" && msg.state?.entries) {
-          setEntries(msg.state.entries);
+        if (msg.type === "state_update") {
+          // Validate the shape before applying so a malformed payload can't
+          // throw at render time.
+          if (Array.isArray(msg.state?.entries)) {
+            setEntries(msg.state.entries);
+          } else {
+            console.warn("[overview WS] ignoring malformed state_update frame");
+          }
         }
       } catch {
         // Ignore malformed frames.
@@ -85,10 +91,13 @@ export function useOverviewWebSocket({ enabled }: { enabled: boolean }): void {
       if (connectionIdRef.current !== thisConnectionId) return;
       setConnected(false);
       if (enabledRef.current) {
-        const delay = Math.min(
+        // Exponential backoff with random jitter (0–500ms) so many clients
+        // don't reconnect in lockstep after a backend restart.
+        const baseDelay = Math.min(
           1000 * Math.pow(2, retryCountRef.current),
           30000,
         );
+        const delay = baseDelay + Math.random() * 500;
         retryCountRef.current++;
         reconnectTimeoutRef.current = setTimeout(() => {
           reconnectTimeoutRef.current = null;

--- a/frontend/src/hooks/useSessions.ts
+++ b/frontend/src/hooks/useSessions.ts
@@ -81,8 +81,9 @@ export function useSessions(
     return null;
   }, []);
 
-  // Fetch sessions on mount and periodically
+  // Fetch sessions on mount and periodically.
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- fetch-on-mount; state updates land in fetchSessions' async resolution, not synchronously
     fetchSessions();
     const interval = setInterval(fetchSessions, 5000);
     return () => clearInterval(interval);
@@ -139,6 +140,7 @@ export function useSessions(
         candidates[0],
       );
       if (bestSession) {
+        // eslint-disable-next-line react-hooks/set-state-in-effect -- one-time auto-select of the initial session once sessions load (guarded by hasAutoSelected)
         setSessionId(bestSession.id);
         showStatus(
           t("status.connectedTo", {

--- a/frontend/src/hooks/useSessions.ts
+++ b/frontend/src/hooks/useSessions.ts
@@ -83,7 +83,6 @@ export function useSessions(
 
   // Fetch sessions on mount and periodically.
   useEffect(() => {
-    // eslint-disable-next-line react-hooks/set-state-in-effect -- fetch-on-mount; state updates land in fetchSessions' async resolution, not synchronously
     fetchSessions();
     const interval = setInterval(fetchSessions, 5000);
     return () => clearInterval(interval);
@@ -140,7 +139,6 @@ export function useSessions(
         candidates[0],
       );
       if (bestSession) {
-        // eslint-disable-next-line react-hooks/set-state-in-effect -- one-time auto-select of the initial session once sessions load (guarded by hasAutoSelected)
         setSessionId(bestSession.id);
         showStatus(
           t("status.connectedTo", {

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -19,6 +19,9 @@ const en = {
   "header.agents": "agents",
   "header.tour": "TOUR",
   "header.commandCenter": "COMMAND",
+  "header.more": "MORE",
+  "header.moreMenu": "More actions",
+  "help.tour": "Take the Tour",
 
   // Command Center
   "commandCenter.title": "Command Center",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -34,6 +34,11 @@ const en = {
   "commandCenter.popup.employees": "Employees",
   "commandCenter.popup.terminal": "Terminal",
   "commandCenter.popup.drillIn": "Open",
+  "commandCenter.initializing": "Initializing Command Center...",
+  "commandCenter.board.allSessions": "ALL SESSIONS",
+  "commandCenter.board.terminals": "Terminals",
+  "commandCenter.board.employees": "Employees",
+  "commandCenter.board.todos": "Todos",
 
   // Modals
   "modal.confirmDbWipe": "Confirm Database Wipe",
@@ -90,6 +95,9 @@ const en = {
     "Add floors and map project folder names to enable building navigation view",
   "settings.building.unsavedWarning":
     "You have unsaved building changes. Discard them?",
+  "settings.building.saveFailed": "Save failed: {status} {statusText}",
+  "settings.building.saveUnreachable":
+    "Cannot reach backend — is the server running?",
 
   // Sessions
   "sessions.title": "Sessions",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -18,6 +18,19 @@ const en = {
   "header.aiOff": "OFF",
   "header.agents": "agents",
   "header.tour": "TOUR",
+  "header.commandCenter": "COMMAND",
+
+  // Command Center
+  "commandCenter.title": "Command Center",
+  "commandCenter.zone.needsYou": "Needs you",
+  "commandCenter.zone.working": "Working",
+  "commandCenter.zone.done": "Done",
+  "commandCenter.zone.ended": "Ended",
+  "commandCenter.moreCount": "+{count} more",
+  "commandCenter.popup.todos": "Todos",
+  "commandCenter.popup.employees": "Employees",
+  "commandCenter.popup.terminal": "Terminal",
+  "commandCenter.popup.drillIn": "Open",
 
   // Modals
   "modal.confirmDbWipe": "Confirm Database Wipe",

--- a/frontend/src/i18n/es.ts
+++ b/frontend/src/i18n/es.ts
@@ -21,6 +21,9 @@ const es: Record<TranslationKey, string> = {
   "header.agents": "agentes",
   "header.tour": "TOUR",
   "header.commandCenter": "MANDO",
+  "header.more": "MÁS",
+  "header.moreMenu": "Más acciones",
+  "help.tour": "Hacer el tour",
 
   // Command Center
   "commandCenter.title": "Centro de Mando",

--- a/frontend/src/i18n/es.ts
+++ b/frontend/src/i18n/es.ts
@@ -20,6 +20,19 @@ const es: Record<TranslationKey, string> = {
   "header.aiOff": "OFF",
   "header.agents": "agentes",
   "header.tour": "TOUR",
+  "header.commandCenter": "MANDO",
+
+  // Command Center
+  "commandCenter.title": "Centro de Mando",
+  "commandCenter.zone.needsYou": "Te necesita",
+  "commandCenter.zone.working": "Trabajando",
+  "commandCenter.zone.done": "Hecho",
+  "commandCenter.zone.ended": "Finalizado",
+  "commandCenter.moreCount": "+{count} más",
+  "commandCenter.popup.todos": "Tareas",
+  "commandCenter.popup.employees": "Empleados",
+  "commandCenter.popup.terminal": "Terminal",
+  "commandCenter.popup.drillIn": "Abrir",
 
   // Modals
   "modal.confirmDbWipe": "Confirmar borrado de base de datos",

--- a/frontend/src/i18n/es.ts
+++ b/frontend/src/i18n/es.ts
@@ -36,6 +36,11 @@ const es: Record<TranslationKey, string> = {
   "commandCenter.popup.employees": "Empleados",
   "commandCenter.popup.terminal": "Terminal",
   "commandCenter.popup.drillIn": "Abrir",
+  "commandCenter.initializing": "Inicializando Centro de Mando...",
+  "commandCenter.board.allSessions": "TODAS LAS SESIONES",
+  "commandCenter.board.terminals": "Terminales",
+  "commandCenter.board.employees": "Empleados",
+  "commandCenter.board.todos": "Tareas",
 
   // Modals
   "modal.confirmDbWipe": "Confirmar borrado de base de datos",
@@ -92,6 +97,9 @@ const es: Record<TranslationKey, string> = {
     "Agrega pisos y mapea nombres de carpetas de proyectos para habilitar la vista de edificio",
   "settings.building.unsavedWarning":
     "Tienes cambios sin guardar en el edificio. ¿Descartarlos?",
+  "settings.building.saveFailed": "Error al guardar: {status} {statusText}",
+  "settings.building.saveUnreachable":
+    "No se puede conectar con el servidor — ¿está en ejecución?",
 
   // Sessions
   "sessions.title": "Sesiones",

--- a/frontend/src/i18n/pt-BR.ts
+++ b/frontend/src/i18n/pt-BR.ts
@@ -21,6 +21,9 @@ const ptBR: Record<TranslationKey, string> = {
   "header.agents": "agentes",
   "header.tour": "TUR",
   "header.commandCenter": "COMANDO",
+  "header.more": "MAIS",
+  "header.moreMenu": "Mais ações",
+  "help.tour": "Fazer o tour",
 
   // Command Center
   "commandCenter.title": "Central de Comando",

--- a/frontend/src/i18n/pt-BR.ts
+++ b/frontend/src/i18n/pt-BR.ts
@@ -20,6 +20,19 @@ const ptBR: Record<TranslationKey, string> = {
   "header.aiOff": "DESLIGADO",
   "header.agents": "agentes",
   "header.tour": "TUR",
+  "header.commandCenter": "COMANDO",
+
+  // Command Center
+  "commandCenter.title": "Central de Comando",
+  "commandCenter.zone.needsYou": "Precisa de você",
+  "commandCenter.zone.working": "Trabalhando",
+  "commandCenter.zone.done": "Concluído",
+  "commandCenter.zone.ended": "Encerrado",
+  "commandCenter.moreCount": "+{count} mais",
+  "commandCenter.popup.todos": "Tarefas",
+  "commandCenter.popup.employees": "Funcionários",
+  "commandCenter.popup.terminal": "Terminal",
+  "commandCenter.popup.drillIn": "Abrir",
 
   // Modals
   "modal.confirmDbWipe": "Confirmar Limpeza do Banco",

--- a/frontend/src/i18n/pt-BR.ts
+++ b/frontend/src/i18n/pt-BR.ts
@@ -36,6 +36,11 @@ const ptBR: Record<TranslationKey, string> = {
   "commandCenter.popup.employees": "Funcionários",
   "commandCenter.popup.terminal": "Terminal",
   "commandCenter.popup.drillIn": "Abrir",
+  "commandCenter.initializing": "Inicializando Central de Comando...",
+  "commandCenter.board.allSessions": "TODAS AS SESSÕES",
+  "commandCenter.board.terminals": "Terminais",
+  "commandCenter.board.employees": "Funcionários",
+  "commandCenter.board.todos": "Tarefas",
 
   // Modals
   "modal.confirmDbWipe": "Confirmar Limpeza do Banco",
@@ -92,6 +97,9 @@ const ptBR: Record<TranslationKey, string> = {
     "Adicione andares e mapeie nomes de pastas de projetos para ativar a visualização de edifício",
   "settings.building.unsavedWarning":
     "Você tem alterações não salvas no edifício. Descartá-las?",
+  "settings.building.saveFailed": "Falha ao salvar: {status} {statusText}",
+  "settings.building.saveUnreachable":
+    "Não foi possível conectar ao servidor — ele está em execução?",
 
   // Sessions
   "sessions.title": "Sessões",

--- a/frontend/src/stores/navigationStore.ts
+++ b/frontend/src/stores/navigationStore.ts
@@ -36,6 +36,10 @@ interface NavigationActions {
   goToBuilding: () => void;
   /** Navigate to a specific floor */
   goToFloor: (floorId: string) => void;
+  /** Navigate to the Command Center (cross-terminal overview) */
+  goToCommand: () => void;
+  /** Navigate to the single office view (keeps building config for back-nav) */
+  goToSingle: () => void;
   /** Set building config from API (auto-switches to building view if floors exist) */
   setBuildingConfig: (config: BuildingConfig) => void;
   /** Update building config in-place without triggering a view change */
@@ -86,6 +90,27 @@ export const useNavigationStore = create<NavigationStore>()((set, get) => ({
       floorId,
       transitionDirection: "zoom-in",
       isTransitioning: true,
+    }),
+
+  // Command Center renders outside ViewTransition, so no transition flags.
+  goToCommand: () =>
+    set({
+      view: "command",
+      floorId: null,
+      transitionDirection: null,
+      isTransitioning: false,
+      transitionOrigin: null,
+    }),
+
+  // Drill from the Command Center into a single session's office. Keeps
+  // buildingConfig so the building/floor navigation remains available.
+  goToSingle: () =>
+    set({
+      view: "single",
+      floorId: null,
+      transitionDirection: null,
+      isTransitioning: false,
+      transitionOrigin: null,
     }),
 
   setBuildingConfig: (config) =>

--- a/frontend/src/stores/overviewStore.ts
+++ b/frontend/src/stores/overviewStore.ts
@@ -31,7 +31,7 @@ export const useOverviewStore = create<OverviewState>()((set) => ({
 
   setEntries: (entries) => set({ entries, lastUpdated: Date.now() }),
   setConnected: (connected) => set({ connected }),
-  clear: () => set({ entries: [], lastUpdated: null }),
+  clear: () => set({ entries: [], lastUpdated: null, connected: false }),
 }));
 
 export const selectOverviewEntries = (s: OverviewState): OverviewEntry[] =>

--- a/frontend/src/stores/overviewStore.ts
+++ b/frontend/src/stores/overviewStore.ts
@@ -21,6 +21,36 @@ interface OverviewState {
 }
 
 // ============================================================================
+// HELPERS
+// ============================================================================
+
+/**
+ * Shallow-equal two entry lists on only the fields consumers read. Lets the
+ * store skip a state update (and the resulting re-render of every consumer)
+ * when a WS frame carries no meaningful change.
+ */
+function entriesEqual(a: OverviewEntry[], b: OverviewEntry[]): boolean {
+  if (a === b) return true;
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) {
+    const x = a[i];
+    const y = b[i];
+    if (
+      x.sessionId !== y.sessionId ||
+      x.bucket !== y.bucket ||
+      x.state !== y.state ||
+      x.currentTask !== y.currentTask ||
+      x.todoDone !== y.todoDone ||
+      x.todoTotal !== y.todoTotal ||
+      x.subagentCount !== y.subagentCount
+    ) {
+      return false;
+    }
+  }
+  return true;
+}
+
+// ============================================================================
 // STORE
 // ============================================================================
 
@@ -29,7 +59,14 @@ export const useOverviewStore = create<OverviewState>()((set) => ({
   connected: false,
   lastUpdated: null,
 
-  setEntries: (entries) => set({ entries, lastUpdated: Date.now() }),
+  setEntries: (entries) =>
+    set((state) =>
+      // Skip the update entirely when nothing consumers care about changed, so
+      // React/zustand bail out and don't re-render consumers every WS frame.
+      entriesEqual(state.entries, entries)
+        ? state
+        : { entries, lastUpdated: Date.now() },
+    ),
   setConnected: (connected) => set({ connected }),
   clear: () => set({ entries: [], lastUpdated: null, connected: false }),
 }));

--- a/frontend/src/stores/overviewStore.ts
+++ b/frontend/src/stores/overviewStore.ts
@@ -1,0 +1,40 @@
+"use client";
+
+import { create } from "zustand";
+import type { OverviewEntry } from "@/types";
+
+// ============================================================================
+// TYPES
+// ============================================================================
+
+interface OverviewState {
+  /** Raw per-session boss snapshots from /ws/overview (live sessions only). */
+  entries: OverviewEntry[];
+  /** Whether the overview WebSocket is currently connected. */
+  connected: boolean;
+  /** Wall-clock ms of the last received update (null if none yet). */
+  lastUpdated: number | null;
+
+  setEntries: (entries: OverviewEntry[]) => void;
+  setConnected: (connected: boolean) => void;
+  clear: () => void;
+}
+
+// ============================================================================
+// STORE
+// ============================================================================
+
+export const useOverviewStore = create<OverviewState>()((set) => ({
+  entries: [],
+  connected: false,
+  lastUpdated: null,
+
+  setEntries: (entries) => set({ entries, lastUpdated: Date.now() }),
+  setConnected: (connected) => set({ connected }),
+  clear: () => set({ entries: [], lastUpdated: null }),
+}));
+
+export const selectOverviewEntries = (s: OverviewState): OverviewEntry[] =>
+  s.entries;
+export const selectOverviewConnected = (s: OverviewState): boolean =>
+  s.connected;

--- a/frontend/src/systems/astar.ts
+++ b/frontend/src/systems/astar.ts
@@ -7,8 +7,8 @@
 
 import { Position } from "@/types";
 import {
-  NavigationGrid,
   GridPosition,
+  PathGrid,
   TILE_SIZE,
   getNavigationGrid,
 } from "./navigationGrid";
@@ -125,9 +125,8 @@ export function findPath(
   start: Position,
   end: Position,
   ignoreAgentId?: string,
+  grid: PathGrid = getNavigationGrid(),
 ): GridPosition[] {
-  const grid = getNavigationGrid();
-
   const startGrid = grid.worldToGrid(start.x, start.y);
   const endGrid = grid.worldToGrid(end.x, end.y);
 
@@ -231,7 +230,7 @@ export function findPath(
  * Find the nearest walkable tile to a position.
  */
 function findNearestWalkable(
-  grid: NavigationGrid,
+  grid: PathGrid,
   pos: GridPosition,
   ignoreAgentId?: string,
 ): GridPosition | null {
@@ -274,8 +273,10 @@ function reconstructPath(goalNode: AStarNode): GridPosition[] {
 /**
  * Convert grid path to world coordinates (pixel positions).
  */
-export function gridPathToWorld(gridPath: GridPosition[]): Position[] {
-  const grid = getNavigationGrid();
+export function gridPathToWorld(
+  gridPath: GridPosition[],
+  grid: PathGrid = getNavigationGrid(),
+): Position[] {
   return gridPath.map((gp) => grid.gridToWorld(gp.gx, gp.gy));
 }
 
@@ -291,8 +292,9 @@ export function findWorldPath(
   start: Position,
   end: Position,
   ignoreAgentId?: string,
+  grid: PathGrid = getNavigationGrid(),
 ): Position[] {
-  const gridPath = findPath(start, end, ignoreAgentId);
+  const gridPath = findPath(start, end, ignoreAgentId, grid);
 
   if (gridPath.length === 0) {
     // No valid path found - log warning and return empty
@@ -303,5 +305,5 @@ export function findWorldPath(
     return [];
   }
 
-  return gridPathToWorld(gridPath);
+  return gridPathToWorld(gridPath, grid);
 }

--- a/frontend/src/systems/commandCenterGrid.ts
+++ b/frontend/src/systems/commandCenterGrid.ts
@@ -72,11 +72,11 @@ class CommandCenterGrid implements PathGrid {
   gridToWorld(gx: number, gy: number): Position {
     return { x: gx * TILE + TILE / 2, y: gy * TILE + TILE / 2 };
   }
-  isWalkable(gx: number, gy: number): boolean {
+  isWalkable(gx: number, gy: number, _ignoreAgentId?: string): boolean {
     if (!this.valid(gx, gy)) return false;
     return this.blocked[this.idx(gx, gy)] === 0;
   }
-  getCost(): number {
+  getCost(_gx?: number, _gy?: number, _ignoreAgentId?: string): number {
     return 1;
   }
   getNeighbors(gx: number, gy: number): GridPosition[] {

--- a/frontend/src/systems/commandCenterGrid.ts
+++ b/frontend/src/systems/commandCenterGrid.ts
@@ -1,0 +1,114 @@
+/**
+ * Navigation grid for the Command Center floor.
+ *
+ * Marks the STATIC furniture (desks, lounge couches, the exit elevator, and the
+ * top wall) as obstacles so walking agents path AROUND them via the shared A*
+ * (astar.ts). Each agent's slot centre is left walkable (the agent stands just
+ * above its desk), and lanes between desk rows/columns stay open.
+ */
+
+import type { Position } from "@/types";
+import type { GridPosition, PathGrid } from "./navigationGrid";
+import { CANVAS_WIDTH, CANVAS_HEIGHT } from "@/constants/canvas";
+import {
+  ZONES,
+  MAX_SLOTS,
+  TOP_WALL_H,
+  slotPosition,
+} from "@/components/command/layout";
+
+const TILE = 32;
+const W = Math.ceil(CANVAS_WIDTH / TILE); // 40
+const H = Math.ceil(CANVAS_HEIGHT / TILE); // 32
+
+class CommandCenterGrid implements PathGrid {
+  private blocked: Uint8Array;
+
+  constructor() {
+    this.blocked = new Uint8Array(W * H);
+    this.build();
+  }
+
+  private idx(gx: number, gy: number): number {
+    return gy * W + gx;
+  }
+  private valid(gx: number, gy: number): boolean {
+    return gx >= 0 && gx < W && gy >= 0 && gy < H;
+  }
+  private mark(x1: number, y1: number, x2: number, y2: number): void {
+    const sgx = Math.floor(x1 / TILE);
+    const egx = Math.ceil(x2 / TILE);
+    const sgy = Math.floor(y1 / TILE);
+    const egy = Math.ceil(y2 / TILE);
+    for (let gx = sgx; gx < egx; gx++)
+      for (let gy = sgy; gy < egy; gy++)
+        if (this.valid(gx, gy)) this.blocked[this.idx(gx, gy)] = 1;
+  }
+
+  private build(): void {
+    // Top wall (posters, board, clock) — agents stay on the floor below it.
+    this.mark(0, 0, CANVAS_WIDTH, TOP_WALL_H);
+
+    for (const zone of ZONES) {
+      if (zone.kind === "exit") {
+        // Elevator doorway (matches CommandCenterFurniture ExitDoor baseY).
+        const cx = zone.x + zone.w / 2;
+        const baseY = zone.y + 150;
+        this.mark(cx - 58, baseY - 130, cx + 58, baseY);
+        continue;
+      }
+      // A furniture footprint just below each slot's standing spot.
+      for (let slot = 0; slot < MAX_SLOTS; slot++) {
+        const p = slotPosition(zone, slot);
+        const halfW = zone.kind === "lounge" ? 50 : 46;
+        this.mark(p.x - halfW, p.y + 8, p.x + halfW, p.y + 40);
+      }
+    }
+  }
+
+  worldToGrid(x: number, y: number): GridPosition {
+    return { gx: Math.floor(x / TILE), gy: Math.floor(y / TILE) };
+  }
+  gridToWorld(gx: number, gy: number): Position {
+    return { x: gx * TILE + TILE / 2, y: gy * TILE + TILE / 2 };
+  }
+  isWalkable(gx: number, gy: number): boolean {
+    if (!this.valid(gx, gy)) return false;
+    return this.blocked[this.idx(gx, gy)] === 0;
+  }
+  getCost(): number {
+    return 1;
+  }
+  getNeighbors(gx: number, gy: number): GridPosition[] {
+    const neighbors: GridPosition[] = [];
+    const dirs = [
+      { dx: 0, dy: -1 },
+      { dx: 1, dy: 0 },
+      { dx: 0, dy: 1 },
+      { dx: -1, dy: 0 },
+      { dx: 1, dy: -1 },
+      { dx: 1, dy: 1 },
+      { dx: -1, dy: 1 },
+      { dx: -1, dy: -1 },
+    ];
+    for (const { dx, dy } of dirs) {
+      const nx = gx + dx;
+      const ny = gy + dy;
+      if (!this.valid(nx, ny)) continue;
+      // Prevent diagonal corner cutting.
+      if (dx !== 0 && dy !== 0) {
+        if (!this.isWalkable(gx + dx, gy) || !this.isWalkable(gx, gy + dy))
+          continue;
+      }
+      neighbors.push({ gx: nx, gy: ny });
+    }
+    return neighbors;
+  }
+}
+
+let instance: CommandCenterGrid | null = null;
+
+export function getCommandCenterGrid(): CommandCenterGrid {
+  if (!instance) instance = new CommandCenterGrid();
+  return instance;
+}

--- a/frontend/src/systems/commandCenterMotion.ts
+++ b/frontend/src/systems/commandCenterMotion.ts
@@ -1,0 +1,172 @@
+"use client";
+
+import { create } from "zustand";
+import { useEffect } from "react";
+import type { Position } from "@/types";
+import { findWorldPath } from "./astar";
+import { smoothPath } from "./pathSmoothing";
+import { getCommandCenterGrid } from "./commandCenterGrid";
+
+/**
+ * Walks Command Center agents to their (fixed) slot positions, pathing AROUND
+ * the static furniture via the shared A* on {@link getCommandCenterGrid}.
+ * Furniture never moves — only the agent body travels. The RAF loop self-gates
+ * (runs only while something is moving), and settled agents keep a stable
+ * Position identity so memoised sprites don't re-render.
+ */
+
+const SPEED = 260; // px/s
+
+interface MotionStore {
+  positions: Map<string, Position>;
+  _set: (positions: Map<string, Position>) => void;
+}
+
+export const useMotionStore = create<MotionStore>()((set) => ({
+  positions: new Map(),
+  _set: (positions) => set({ positions }),
+}));
+
+export const selectMotionPos =
+  (id: string) =>
+  (s: MotionStore): Position | undefined =>
+    s.positions.get(id);
+
+// ---- internal mover state (outside React) ----
+interface PathState {
+  waypoints: Position[];
+  index: number;
+}
+const current = new Map<string, Position>();
+const target = new Map<string, Position>();
+const paths = new Map<string, PathState>();
+let rafId: number | null = null;
+let lastTime = 0;
+
+function computePath(from: Position, to: Position, id: string): Position[] {
+  const raw = findWorldPath(from, to, id, getCommandCenterGrid());
+  if (raw.length < 2) return [{ ...from }, { ...to }]; // fallback: straight
+  const sm = smoothPath(raw);
+  if (sm.length >= 2) {
+    sm[0] = { ...from };
+    sm[sm.length - 1] = { ...to };
+  }
+  return sm;
+}
+
+function publish(): void {
+  const prev = useMotionStore.getState().positions;
+  const next = new Map<string, Position>();
+  for (const [id, cur] of current) {
+    const old = prev.get(id);
+    if (old && old.x === cur.x && old.y === cur.y) next.set(id, old);
+    else next.set(id, { x: cur.x, y: cur.y });
+  }
+  useMotionStore.getState()._set(next);
+}
+
+/** Advance one agent along its path. Returns true if it moved. */
+function advance(id: string, dt: number): boolean {
+  const path = paths.get(id);
+  const cur = current.get(id);
+  if (!path || !cur) return false;
+  let { index } = path;
+  const wp = path.waypoints;
+  if (index >= wp.length - 1) {
+    paths.delete(id);
+    return false;
+  }
+  let remaining = SPEED * dt;
+  let pos: Position = cur;
+  while (remaining > 0 && index < wp.length - 1) {
+    const next = wp[index + 1];
+    const dx = next.x - pos.x;
+    const dy = next.y - pos.y;
+    const seg = Math.hypot(dx, dy);
+    if (seg < 0.1) {
+      index++;
+      continue;
+    }
+    if (remaining >= seg) {
+      remaining -= seg;
+      pos = { x: next.x, y: next.y };
+      index++;
+    } else {
+      const t = remaining / seg;
+      pos = { x: pos.x + dx * t, y: pos.y + dy * t };
+      remaining = 0;
+    }
+  }
+  current.set(id, pos);
+  path.index = index;
+  if (index >= wp.length - 1) paths.delete(id);
+  return true;
+}
+
+function tick(): void {
+  const now = performance.now();
+  const dt = Math.min((now - lastTime) / 1000, 0.05);
+  lastTime = now;
+
+  let moving = false;
+  for (const id of current.keys()) {
+    if (advance(id, dt)) moving = true;
+  }
+
+  publish();
+  if (moving) rafId = requestAnimationFrame(tick);
+  else rafId = null;
+}
+
+function ensureRaf(): void {
+  if (rafId === null) {
+    lastTime = performance.now();
+    rafId = requestAnimationFrame(tick);
+  }
+}
+
+/** Reconcile the desired agents + their fixed slot targets. */
+export function setMotionTargets(items: { id: string; target: Position }[]): void {
+  const wanted = new Set(items.map((i) => i.id));
+  for (const id of [...current.keys()]) {
+    if (!wanted.has(id)) {
+      current.delete(id);
+      target.delete(id);
+      paths.delete(id);
+    }
+  }
+  let needsRaf = false;
+  for (const { id, target: tgt } of items) {
+    if (!current.has(id)) {
+      // New agent: appear at its slot (no walk on first show).
+      current.set(id, { x: tgt.x, y: tgt.y });
+      target.set(id, { x: tgt.x, y: tgt.y });
+    } else {
+      const t = target.get(id);
+      if (!t || Math.abs(t.x - tgt.x) > 1 || Math.abs(t.y - tgt.y) > 1) {
+        target.set(id, { x: tgt.x, y: tgt.y });
+        paths.set(id, {
+          waypoints: computePath(current.get(id)!, tgt, id),
+          index: 0,
+        });
+        needsRaf = true;
+      }
+    }
+  }
+  publish();
+  if (needsRaf) ensureRaf();
+}
+
+/** Stop the loop and clear state when the Command Center unmounts. */
+export function useMotionCleanup(): void {
+  useEffect(() => {
+    return () => {
+      if (rafId !== null) cancelAnimationFrame(rafId);
+      rafId = null;
+      current.clear();
+      target.clear();
+      paths.clear();
+      useMotionStore.getState()._set(new Map());
+    };
+  }, []);
+}

--- a/frontend/src/systems/commandCenterMotion.ts
+++ b/frontend/src/systems/commandCenterMotion.ts
@@ -6,6 +6,8 @@ import type { Position } from "@/types";
 import { findWorldPath } from "./astar";
 import { smoothPath } from "./pathSmoothing";
 import { getCommandCenterGrid } from "./commandCenterGrid";
+import { resetExit } from "./exitAnimation";
+import { resetSlotAlloc } from "@/components/command/useCommandCenterPeers";
 
 /**
  * Walks Command Center agents to their (fixed) slot positions, pathing AROUND
@@ -44,9 +46,12 @@ let rafId: number | null = null;
 let lastTime = 0;
 
 function computePath(from: Position, to: Position, id: string): Position[] {
-  const raw = findWorldPath(from, to, id, getCommandCenterGrid());
-  if (raw.length < 2) return [{ ...from }, { ...to }]; // fallback: straight
-  const sm = smoothPath(raw);
+  const grid = getCommandCenterGrid();
+  const raw = findWorldPath(from, to, id, grid);
+  // No valid route: return empty so the caller snaps the peer to its slot
+  // instead of animating a straight line through CC furniture.
+  if (raw.length < 2) return [];
+  const sm = smoothPath(raw, grid);
   if (sm.length >= 2) {
     sm[0] = { ...from };
     sm[sm.length - 1] = { ...to };
@@ -126,7 +131,9 @@ function ensureRaf(): void {
 }
 
 /** Reconcile the desired agents + their fixed slot targets. */
-export function setMotionTargets(items: { id: string; target: Position }[]): void {
+export function setMotionTargets(
+  items: { id: string; target: Position }[],
+): void {
   const wanted = new Set(items.map((i) => i.id));
   for (const id of [...current.keys()]) {
     if (!wanted.has(id)) {
@@ -145,11 +152,16 @@ export function setMotionTargets(items: { id: string; target: Position }[]): voi
       const t = target.get(id);
       if (!t || Math.abs(t.x - tgt.x) > 1 || Math.abs(t.y - tgt.y) > 1) {
         target.set(id, { x: tgt.x, y: tgt.y });
-        paths.set(id, {
-          waypoints: computePath(current.get(id)!, tgt, id),
-          index: 0,
-        });
-        needsRaf = true;
+        const waypoints = computePath(current.get(id)!, tgt, id);
+        if (waypoints.length < 2) {
+          // No walkable route: snap straight to the slot (no wall-crossing
+          // animation) so the peer still reaches its destination.
+          current.set(id, { x: tgt.x, y: tgt.y });
+          paths.delete(id);
+        } else {
+          paths.set(id, { waypoints, index: 0 });
+          needsRaf = true;
+        }
       }
     }
   }
@@ -167,6 +179,10 @@ export function useMotionCleanup(): void {
       target.clear();
       paths.clear();
       useMotionStore.getState()._set(new Map());
+      // Clear sibling module-level state so a re-mount starts clean (no stale
+      // slot reservations, no exit flash at the elevator).
+      resetSlotAlloc();
+      resetExit();
     };
   }, []);
 }

--- a/frontend/src/systems/exitAnimation.ts
+++ b/frontend/src/systems/exitAnimation.ts
@@ -69,6 +69,7 @@ export function selectDoorOpen(s: ExitState): boolean {
 /** Drives the per-frame clock while the Command Center is mounted. */
 export function useExitDriver(): void {
   const rafRef = useRef<number | null>(null);
+  const wasActiveRef = useRef(false);
   useEffect(() => {
     const tick = () => {
       const now = performance.now();
@@ -76,13 +77,20 @@ export function useExitDriver(): void {
       // Only advance the clock while an exit is actually mid-animation, so we
       // don't spam store updates (and re-renders) when nobody is leaving.
       let active = false;
+      let latestFinish = 0;
       for (const st of s.startTimes.values()) {
-        if ((now - st) / EXIT_DURATION < 1) {
-          active = true;
-          break;
-        }
+        if ((now - st) / EXIT_DURATION < 1) active = true;
+        latestFinish = Math.max(latestFinish, st + EXIT_DURATION);
       }
-      if (active) s.setNow(now);
+      if (active) {
+        s.setNow(now);
+      } else if (wasActiveRef.current && s.now < latestFinish) {
+        // The frame where exits cross the finish line: pin the clock to (or
+        // past) the last finish boundary so exitProgress reaches exactly 1 and
+        // exited peers don't linger.
+        s.setNow(latestFinish);
+      }
+      wasActiveRef.current = active;
       rafRef.current = requestAnimationFrame(tick);
     };
     rafRef.current = requestAnimationFrame(tick);

--- a/frontend/src/systems/exitAnimation.ts
+++ b/frontend/src/systems/exitAnimation.ts
@@ -1,0 +1,93 @@
+"use client";
+
+import { create } from "zustand";
+import { useEffect, useRef } from "react";
+
+/**
+ * Lightweight exit animation for the Command Center "Ended" column. When a
+ * session ends, its agent walks to the elevator, the doors open, the agent
+ * steps in and fades out. Isolated from the rest of the canvas: only the
+ * exiting agents and the door subscribe to the per-frame clock.
+ */
+
+export const EXIT_DURATION = 2400; // ms for the full walk-in-and-fade
+
+interface ExitState {
+  /** Monotonic clock (performance.now), bumped each animation frame. */
+  now: number;
+  /** sessionId → time (performance.now) the exit started. */
+  startTimes: Map<string, number>;
+  setNow: (now: number) => void;
+  /** Register the current ended sessions; new ones start their exit now. */
+  registerEnded: (ids: string[], t: number) => void;
+}
+
+export const useExitStore = create<ExitState>()((set) => ({
+  now: 0,
+  startTimes: new Map(),
+  setNow: (now) => set({ now }),
+  registerEnded: (ids, t) =>
+    set((s) => {
+      const idSet = new Set(ids);
+      const next = new Map(s.startTimes);
+      let changed = false;
+      for (const id of ids)
+        if (!next.has(id)) {
+          next.set(id, t);
+          changed = true;
+        }
+      for (const id of [...next.keys()])
+        if (!idSet.has(id)) {
+          next.delete(id);
+          changed = true;
+        }
+      // Preserve Map identity when nothing changed (avoids re-render churn).
+      return changed ? { startTimes: next } : {};
+    }),
+}));
+
+/** 0→1 progress of a session's exit (0 if not exiting, 1 when fully gone). */
+export function exitProgress(
+  id: string,
+  now: number,
+  startTimes: Map<string, number>,
+): number {
+  const st = startTimes.get(id);
+  if (st == null) return 0;
+  return Math.min(1, Math.max(0, (now - st) / EXIT_DURATION));
+}
+
+/** True while any agent is mid-exit (doors should be open). */
+export function selectDoorOpen(s: ExitState): boolean {
+  for (const st of s.startTimes.values()) {
+    const p = Math.min(1, Math.max(0, (s.now - st) / EXIT_DURATION));
+    if (p >= 0.35 && p < 0.95) return true;
+  }
+  return false;
+}
+
+/** Drives the per-frame clock while the Command Center is mounted. */
+export function useExitDriver(): void {
+  const rafRef = useRef<number | null>(null);
+  useEffect(() => {
+    const tick = () => {
+      const now = performance.now();
+      const s = useExitStore.getState();
+      // Only advance the clock while an exit is actually mid-animation, so we
+      // don't spam store updates (and re-renders) when nobody is leaving.
+      let active = false;
+      for (const st of s.startTimes.values()) {
+        if ((now - st) / EXIT_DURATION < 1) {
+          active = true;
+          break;
+        }
+      }
+      if (active) s.setNow(now);
+      rafRef.current = requestAnimationFrame(tick);
+    };
+    rafRef.current = requestAnimationFrame(tick);
+    return () => {
+      if (rafRef.current !== null) cancelAnimationFrame(rafRef.current);
+    };
+  }, []);
+}

--- a/frontend/src/systems/exitAnimation.ts
+++ b/frontend/src/systems/exitAnimation.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import { create } from "zustand";
-import { useEffect, useRef } from "react";
+import { useEffect } from "react";
 
 /**
  * Lightweight exit animation for the Command Center "Ended" column. When a
@@ -20,13 +20,16 @@ interface ExitState {
   setNow: (now: number) => void;
   /** Register the current ended sessions; new ones start their exit now. */
   registerEnded: (ids: string[], t: number) => void;
+  /** Drop sessions whose exit animation has finished by `now`. */
+  pruneCompleted: (now: number) => void;
 }
 
 export const useExitStore = create<ExitState>()((set) => ({
   now: 0,
   startTimes: new Map(),
   setNow: (now) => set({ now }),
-  registerEnded: (ids, t) =>
+  registerEnded: (ids, t) => {
+    let added = false;
     set((s) => {
       const idSet = new Set(ids);
       const next = new Map(s.startTimes);
@@ -35,6 +38,7 @@ export const useExitStore = create<ExitState>()((set) => ({
         if (!next.has(id)) {
           next.set(id, t);
           changed = true;
+          added = true;
         }
       for (const id of [...next.keys()])
         if (!idSet.has(id)) {
@@ -43,8 +47,28 @@ export const useExitStore = create<ExitState>()((set) => ({
         }
       // Preserve Map identity when nothing changed (avoids re-render churn).
       return changed ? { startTimes: next } : {};
+    });
+    // Re-arm the self-gating driver loop when a new exit begins.
+    if (added) ensureExitRaf();
+  },
+  pruneCompleted: (now) =>
+    set((s) => {
+      const next = new Map(s.startTimes);
+      let changed = false;
+      for (const [id, st] of s.startTimes)
+        if ((now - st) / EXIT_DURATION >= 1) {
+          next.delete(id);
+          changed = true;
+        }
+      // Preserve Map identity when nothing changed (avoids re-render churn).
+      return changed ? { startTimes: next } : {};
     }),
 }));
+
+/** Clear all exit state (call on Command Center unmount). */
+export function resetExit(): void {
+  useExitStore.setState({ now: 0, startTimes: new Map() });
+}
 
 /** 0→1 progress of a session's exit (0 if not exiting, 1 when fully gone). */
 export function exitProgress(
@@ -66,36 +90,57 @@ export function selectDoorOpen(s: ExitState): boolean {
   return false;
 }
 
+// ---- self-gating driver loop (mirrors commandCenterMotion) ----
+let rafId: number | null = null;
+let wasActive = false;
+
+function tick(): void {
+  const now = performance.now();
+  const s = useExitStore.getState();
+  // Only advance the clock while an exit is actually mid-animation, so we
+  // don't spam store updates (and re-renders) when nobody is leaving.
+  let active = false;
+  let latestFinish = 0;
+  for (const st of s.startTimes.values()) {
+    if ((now - st) / EXIT_DURATION < 1) active = true;
+    latestFinish = Math.max(latestFinish, st + EXIT_DURATION);
+  }
+  if (active) {
+    s.setNow(now);
+  } else if (wasActive && s.now < latestFinish) {
+    // The frame where exits cross the finish line: pin the clock to (or
+    // past) the last finish boundary so exitProgress reaches exactly 1 and
+    // exited peers don't linger.
+    s.setNow(latestFinish);
+  }
+  wasActive = active;
+  if (active) {
+    rafId = requestAnimationFrame(tick);
+  } else {
+    // Nothing animating: drop finished exits and stop the loop. It re-arms
+    // from registerEnded when the next session leaves.
+    s.pruneCompleted(now);
+    rafId = null;
+  }
+}
+
+/** Start the self-gating driver loop if it isn't already running. */
+function ensureExitRaf(): void {
+  if (rafId === null && typeof requestAnimationFrame !== "undefined") {
+    rafId = requestAnimationFrame(tick);
+  }
+}
+
 /** Drives the per-frame clock while the Command Center is mounted. */
 export function useExitDriver(): void {
-  const rafRef = useRef<number | null>(null);
-  const wasActiveRef = useRef(false);
   useEffect(() => {
-    const tick = () => {
-      const now = performance.now();
-      const s = useExitStore.getState();
-      // Only advance the clock while an exit is actually mid-animation, so we
-      // don't spam store updates (and re-renders) when nobody is leaving.
-      let active = false;
-      let latestFinish = 0;
-      for (const st of s.startTimes.values()) {
-        if ((now - st) / EXIT_DURATION < 1) active = true;
-        latestFinish = Math.max(latestFinish, st + EXIT_DURATION);
-      }
-      if (active) {
-        s.setNow(now);
-      } else if (wasActiveRef.current && s.now < latestFinish) {
-        // The frame where exits cross the finish line: pin the clock to (or
-        // past) the last finish boundary so exitProgress reaches exactly 1 and
-        // exited peers don't linger.
-        s.setNow(latestFinish);
-      }
-      wasActiveRef.current = active;
-      rafRef.current = requestAnimationFrame(tick);
-    };
-    rafRef.current = requestAnimationFrame(tick);
+    ensureExitRaf();
     return () => {
-      if (rafRef.current !== null) cancelAnimationFrame(rafRef.current);
+      if (rafId !== null) {
+        cancelAnimationFrame(rafId);
+        rafId = null;
+      }
+      wasActive = false;
     };
   }, []);
 }

--- a/frontend/src/systems/exitAnimation.ts
+++ b/frontend/src/systems/exitAnimation.ts
@@ -141,6 +141,9 @@ export function useExitDriver(): void {
         rafId = null;
       }
       wasActive = false;
+      // Defensive: clear module-level exit state on unmount so a later mount
+      // can't briefly observe stale startTimes (useMotionCleanup also resets).
+      resetExit();
     };
   }, []);
 }

--- a/frontend/src/systems/navigationGrid.ts
+++ b/frontend/src/systems/navigationGrid.ts
@@ -81,6 +81,18 @@ export interface GridPosition {
   gy: number;
 }
 
+/**
+ * Minimal grid surface the A* pathfinder depends on. Implemented by the office
+ * {@link NavigationGrid} and by the Command Center grid, so A* can run on either.
+ */
+export interface PathGrid {
+  worldToGrid(x: number, y: number): GridPosition;
+  gridToWorld(gx: number, gy: number): Position;
+  isWalkable(gx: number, gy: number, ignoreAgentId?: string): boolean;
+  getCost(gx: number, gy: number, ignoreAgentId?: string): number;
+  getNeighbors(gx: number, gy: number): GridPosition[];
+}
+
 export interface DynamicObstacle {
   type: "agent" | "furniture";
   agentId?: string;

--- a/frontend/src/systems/pathSmoothing.ts
+++ b/frontend/src/systems/pathSmoothing.ts
@@ -8,6 +8,7 @@
 
 import { Position } from "@/types";
 import { getNavigationGrid, TILE_SIZE } from "./navigationGrid";
+import type { PathGrid } from "./navigationGrid";
 
 /**
  * Simplify path by removing collinear points.
@@ -55,9 +56,11 @@ export function removeCollinearPoints(path: Position[]): Position[] {
  * Check if a straight line between two points is walkable.
  * Uses Bresenham-like line sampling.
  */
-function isLineWalkable(start: Position, end: Position): boolean {
-  const grid = getNavigationGrid();
-
+function isLineWalkable(
+  start: Position,
+  end: Position,
+  grid: PathGrid = getNavigationGrid(),
+): boolean {
   const dx = end.x - start.x;
   const dy = end.y - start.y;
   const distance = Math.sqrt(dx * dx + dy * dy);
@@ -83,7 +86,10 @@ function isLineWalkable(start: Position, end: Position): boolean {
  * Apply funnel algorithm to remove unnecessary waypoints.
  * Greedily tries to skip waypoints while maintaining valid path.
  */
-export function applyFunnelAlgorithm(path: Position[]): Position[] {
+export function applyFunnelAlgorithm(
+  path: Position[],
+  grid: PathGrid = getNavigationGrid(),
+): Position[] {
   if (path.length <= 2) return path;
 
   const result: Position[] = [path[0]];
@@ -94,7 +100,7 @@ export function applyFunnelAlgorithm(path: Position[]): Position[] {
     let furthest = current + 1;
 
     for (let i = path.length - 1; i > current + 1; i--) {
-      if (isLineWalkable(path[current], path[i])) {
+      if (isLineWalkable(path[current], path[i], grid)) {
         furthest = i;
         break;
       }
@@ -126,8 +132,10 @@ function quadraticBezier(
 /**
  * Check if a single point is walkable.
  */
-function isPointWalkable(point: Position): boolean {
-  const grid = getNavigationGrid();
+function isPointWalkable(
+  point: Position,
+  grid: PathGrid = getNavigationGrid(),
+): boolean {
   const gridPos = grid.worldToGrid(point.x, point.y);
   return grid.isWalkable(gridPos.gx, gridPos.gy);
 }
@@ -140,11 +148,12 @@ function isCurveWalkable(
   controlPoint: Position,
   curveEnd: Position,
   samples: number,
+  grid: PathGrid = getNavigationGrid(),
 ): boolean {
   for (let j = 0; j <= samples; j++) {
     const t = j / samples;
     const point = quadraticBezier(curveStart, controlPoint, curveEnd, t);
-    if (!isPointWalkable(point)) {
+    if (!isPointWalkable(point, grid)) {
       return false;
     }
   }
@@ -159,6 +168,7 @@ function isCurveWalkable(
 export function applyBezierSmoothing(
   path: Position[],
   cornerRadius: number = TILE_SIZE * 0.75,
+  grid: PathGrid = getNavigationGrid(),
 ): Position[] {
   if (path.length <= 2) return path;
 
@@ -208,7 +218,7 @@ export function applyBezierSmoothing(
 
     // Check if all curve points are walkable before applying smoothing
     const samples = 4; // Number of intermediate points
-    if (!isCurveWalkable(curveStart, curr, curveEnd, samples)) {
+    if (!isCurveWalkable(curveStart, curr, curveEnd, samples, grid)) {
       // Curve would pass through obstacle, keep original waypoint
       result.push(curr);
       continue;
@@ -230,19 +240,24 @@ export function applyBezierSmoothing(
  * Full path smoothing pipeline.
  *
  * @param path - Raw grid-aligned path from A*
+ * @param grid - Grid to validate cut corners against (defaults to the office
+ *   navigation grid so existing office callers are unchanged)
  * @returns Smoothed path suitable for animation
  */
-export function smoothPath(path: Position[]): Position[] {
+export function smoothPath(
+  path: Position[],
+  grid: PathGrid = getNavigationGrid(),
+): Position[] {
   if (path.length <= 1) return path;
 
   // Step 1: Remove collinear points
   let smoothed = removeCollinearPoints(path);
 
   // Step 2: Apply funnel algorithm to skip unnecessary waypoints
-  smoothed = applyFunnelAlgorithm(smoothed);
+  smoothed = applyFunnelAlgorithm(smoothed, grid);
 
   // Step 3: Apply bezier smoothing at corners
-  smoothed = applyBezierSmoothing(smoothed);
+  smoothed = applyBezierSmoothing(smoothed, undefined, grid);
 
   // Step 4: Final cleanup - remove any duplicate adjacent points
   return removeDuplicatePoints(smoothed);

--- a/frontend/src/types/generated.ts
+++ b/frontend/src/types/generated.ts
@@ -271,6 +271,14 @@ export type LastUpdated = string;
  * Path to the repository
  */
 export type RepoPath = string;
+export type Sessionid1 = string;
+export type Bucket = "needs_you" | "working" | "done";
+export type Currenttask2 = string | null;
+export type Tododone = number;
+export type Todototal = number;
+export type Subagentcount = number;
+export type Entries = OverviewEntry[];
+export type Lastupdated1 = string;
 /**
  * Visual states for the boss's phone.
  *
@@ -639,6 +647,33 @@ export interface GitStatus {
   commits?: Commits;
   last_updated?: LastUpdated;
   repo_path: RepoPath;
+  [k: string]: unknown;
+}
+/**
+ * A single session's boss snapshot for the Command Center.
+ *
+ * This interface was referenced by `ClaudeOfficeBackendTypes`'s JSON-Schema
+ * via the `definition` "OverviewEntry".
+ */
+export interface OverviewEntry {
+  sessionId: Sessionid1;
+  bucket: Bucket;
+  state: BossState;
+  currentTask?: Currenttask2;
+  todoDone?: Tododone;
+  todoTotal?: Todototal;
+  subagentCount?: Subagentcount;
+  [k: string]: unknown;
+}
+/**
+ * The full cross-session overview broadcast over ``/ws/overview``.
+ *
+ * This interface was referenced by `ClaudeOfficeBackendTypes`'s JSON-Schema
+ * via the `definition` "OverviewState".
+ */
+export interface OverviewState {
+  entries?: Entries;
+  lastUpdated: Lastupdated1;
   [k: string]: unknown;
 }
 /**

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -47,10 +47,16 @@ export type {
   EventType,
   EventData,
   Event,
+  // Overview (Command Center)
+  OverviewEntry,
+  OverviewState,
 } from "./generated";
 
 // Re-export Commit with the legacy GitCommit alias for backward compatibility
 export type { Commit, Commit as GitCommit } from "./generated";
+
+// Re-export the overview status bucket under a descriptive name
+export type { Bucket as OverviewBucket } from "./generated";
 
 // ============================================================================
 // FRONTEND-ONLY TYPES — not derived from backend models

--- a/frontend/src/types/navigation.ts
+++ b/frontend/src/types/navigation.ts
@@ -6,7 +6,7 @@
  */
 
 /** Current view mode */
-export type ViewMode = "single" | "building" | "floor";
+export type ViewMode = "single" | "building" | "floor" | "command";
 
 /** Sentinel floor ID for the lobby (unmatched sessions) */
 export const LOBBY_FLOOR_ID = "__lobby__";

--- a/frontend/tests/commandCenterPath.test.ts
+++ b/frontend/tests/commandCenterPath.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from "vitest";
+import { getCommandCenterGrid } from "@/systems/commandCenterGrid";
+import { ZONES, slotPosition, MAX_SLOTS } from "@/components/command/layout";
+import { findWorldPath } from "@/systems/astar";
+import { smoothPath } from "@/systems/pathSmoothing";
+import type { Position } from "@/types";
+import type { PathGrid } from "@/systems/navigationGrid";
+
+/**
+ * Densely sample every segment of a path and count points that land on a
+ * blocked tile of `grid`, excluding the start/end tiles.
+ *
+ * A Command Center slot's standing spot is intentionally one tile above its
+ * desk footprint, and many lower slot centres sit on the (blocked) footprint
+ * tile itself. A* therefore snaps such endpoints to the nearest walkable tile,
+ * but the motion code pins the rendered endpoint back to the exact slot. We
+ * exempt the endpoints' own tiles so the assertion targets what actually
+ * matters: the path must not cut through *other* furniture en route.
+ */
+function blockedSamples(
+  path: Position[],
+  grid: PathGrid,
+  from: Position,
+  to: Position,
+): number {
+  const fg = grid.worldToGrid(from.x, from.y);
+  const tg = grid.worldToGrid(to.x, to.y);
+  const exempt = new Set([`${fg.gx},${fg.gy}`, `${tg.gx},${tg.gy}`]);
+
+  let blocked = 0;
+  for (let i = 1; i < path.length; i++) {
+    const a = path[i - 1];
+    const b = path[i];
+    const dist = Math.hypot(b.x - a.x, b.y - a.y);
+    const steps = Math.max(1, Math.ceil(dist / 4)); // ~4px resolution
+    for (let s = 0; s <= steps; s++) {
+      const t = s / steps;
+      const gp = grid.worldToGrid(a.x + (b.x - a.x) * t, a.y + (b.y - a.y) * t);
+      if (!grid.isWalkable(gp.gx, gp.gy) && !exempt.has(`${gp.gx},${gp.gy}`))
+        blocked++;
+    }
+  }
+  return blocked;
+}
+
+/** Build a CC path the way commandCenterMotion.computePath does. */
+function ccPath(from: Position, to: Position): Position[] {
+  const grid = getCommandCenterGrid();
+  const raw = findWorldPath(from, to, "test-agent", grid);
+  const sm = smoothPath(raw, grid);
+  if (sm.length >= 2) {
+    sm[0] = { ...from };
+    sm[sm.length - 1] = { ...to };
+  }
+  return sm;
+}
+
+describe("Command Center pathfinding", () => {
+  it("smoothed path never cuts through Command Center furniture", () => {
+    const grid = getCommandCenterGrid();
+
+    // In every desk/lounge column, walk top slot -> bottom slot of the same
+    // sub-column. A straight line between them runs through the desk footprints,
+    // so the route MUST weave around them.
+    for (const zone of ZONES) {
+      if (zone.kind === "exit") continue;
+      const from = slotPosition(zone, 0);
+      const to = slotPosition(zone, MAX_SLOTS - 2); // same sub-column, last row
+
+      const raw = findWorldPath(from, to, "test-agent", grid);
+      expect(raw.length).toBeGreaterThanOrEqual(2);
+
+      const sm = ccPath(from, to);
+      // The smoothed route is non-trivial...
+      expect(sm.length).toBeGreaterThanOrEqual(2);
+      // ...and crosses no Command Center furniture other than its endpoints.
+      expect(blockedSamples(sm, grid, from, to)).toBe(0);
+      // Guard: the equivalent straight line WOULD cut through furniture, so the
+      // assertion above is meaningful (the path really had to route around).
+      expect(blockedSamples([from, to], grid, from, to)).toBeGreaterThan(0);
+    }
+  });
+
+  it("smoothing validates against the Command Center grid, not the office grid", () => {
+    // Regression for the cut-corner bug: smoothPath used to validate skipped
+    // waypoints against the OFFICE navigation grid, letting the funnel shortcut
+    // through Command Center furniture (tiles walkable in the office but blocked
+    // here). Smoothing with the CC grid must keep the path clear.
+    const grid = getCommandCenterGrid();
+    const from: Position = { x: 16, y: 176 };
+    const to: Position = { x: 80, y: 368 };
+    const raw = findWorldPath(from, to, "test-agent", grid);
+    expect(raw.length).toBeGreaterThanOrEqual(3);
+
+    // Buggy behaviour: default grid arg == office grid.
+    const buggy = smoothPath(raw);
+    buggy[0] = { ...from };
+    buggy[buggy.length - 1] = { ...to };
+    expect(blockedSamples(buggy, grid, from, to)).toBeGreaterThan(0);
+
+    // Fixed behaviour: smoothing against the CC grid keeps it clear.
+    const fixed = smoothPath(raw, grid);
+    fixed[0] = { ...from };
+    fixed[fixed.length - 1] = { ...to };
+    expect(blockedSamples(fixed, grid, from, to)).toBe(0);
+  });
+});

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from "vitest/config";
+import { fileURLToPath } from "node:url";
+
+// Resolve the "@/*" → "src/*" path alias (mirrors tsconfig.json) so unit tests
+// can import source modules that use the alias internally.
+export default defineConfig({
+  resolve: {
+    alias: {
+      "@": fileURLToPath(new URL("./src", import.meta.url)),
+    },
+  },
+});

--- a/hooks/pyproject.toml
+++ b/hooks/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "claude-office-hooks"
-version = "0.19.0"
+version = "0.20.0"
 description = "Hooks for Claude Office Visualizer"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/hooks/src/claude_office_hooks/main.py
+++ b/hooks/src/claude_office_hooks/main.py
@@ -33,7 +33,7 @@ try:
     from claude_office_hooks.debug_logger import debug_log
     from claude_office_hooks.event_mapper import map_event
 
-    __version__ = "0.19.0"
+    __version__ = "0.20.0"
 
     # Load config at module init so DEBUG flag is available immediately
     _config = load_config()

--- a/opencode-plugin/package.json
+++ b/opencode-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencode-claude-office",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "description": "OpenCode plugin that sends lifecycle events to Claude Office Visualizer",
   "type": "module",
   "main": "dist/index.js",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "claude-office"
-version = "0.19.0"
+version = "0.20.0"
 description = "Real-time pixel art office simulation visualizing Claude Code operations"
 readme = "README.md"
 authors = [

--- a/scripts/gen_types.py
+++ b/scripts/gen_types.py
@@ -21,6 +21,7 @@ from app.models.agents import Agent, Boss, ElevatorState, OfficeState, PhoneStat
 from app.models.common import BubbleContent, BubbleType, SpeechContent, TodoItem, TodoStatus  # noqa: E402  # type: ignore[import]
 from app.models.events import Event, EventData, EventType  # noqa: E402  # type: ignore[import]
 from app.models.git import ChangedFile, Commit, FileStatus, GitStatus  # noqa: E402  # type: ignore[import]
+from app.models.overview import OverviewEntry, OverviewState  # noqa: E402  # type: ignore[import]
 from app.models.sessions import (  # noqa: E402  # type: ignore[import]
     AgentLifespan,
     BackgroundTask,
@@ -54,6 +55,8 @@ MODELS = [
     ChangedFile,
     Commit,
     GitStatus,
+    OverviewEntry,
+    OverviewState,
 ]
 
 # Generate combined JSON schema with camelCase field names (by_alias=True)


### PR DESCRIPTION
## Command Center — cross-terminal session overview

Adds a new top-level view that gathers the **boss (main agent) of every live session** into a single open-plan office, so you can see all your terminals at once and tell what's finished vs. running vs. needs your attention.

### What it does
- Four status **columns** (left→right by priority): ⚠ Needs-you · 🟢 Working · ✅ Done (lounge) · ⚪ Ended (EXIT).
- Each agent is a pixel character that **walks** to a **free seat** — A* pathfinding **around** the static furniture; no reserved spots and no reshuffling when other sessions come or go.
- When a session's terminal closes while you're watching, its agent **walks out the elevator** (doors open) and is gone. (Sessions already finished before you opened the view are not shown.)
- Top wall: an **ALL SESSIONS board** with combined stats (terminal/status counts, total subagents, aggregate todo progress) + a **wall clock** (reused from the office).
- Click an agent → popover to **open its terminal** or **drill into** its office.
- Reachable from a header **COMMAND** button (when ≥2 active sessions) and a tile in the Building view; breadcrumb back to the building.

### Implementation
- **Backend:** new `OverviewEntry`/`OverviewState` models, `build_overview()` peer merge in `room_orchestrator`, and a `/ws/overview` WebSocket. It's declared **before** `/ws/{session_id}` so the single-segment path isn't captured by the session route (a real bug — guarded by a route-order test); the payload is rebuilt only when a client is connected. A* is now grid-parameterized so the Command Center paths on its own grid without touching the office grid.
- **Frontend:** `command` ViewMode, `overviewStore` + `useOverviewWebSocket`, and a sibling PixiJS canvas that **reuses the office sprites/textures** (desks, chairs, monitors, couches, elevator, posters, clock). New i18n keys (en/es/pt-BR); generated types regenerated.
- Version bump to **0.20.0**; tests added for the overview merge, the `/ws/overview` connection manager + broadcast, and the route ordering. `make checkall` is green (backend ruff/pyright/pytest; frontend tsc/eslint/vitest).

### Note
This branch is **stacked on #44** (the full-system QA sweep), so the diff currently also includes those commits — it will narrow to just the Command Center once #44 is merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Command Center view with a live cross-session overview, per-zone progress, and clickable peers for drill-in.
  * Building view now scrolls the floor list when it overflows (and stays centered when it fits) and includes a Command Center quick-access tile.
* **Bug Fixes**
  * Improved overview reliability: replay now ignores unknown event types, conversation history is capped, and timestamps use UTC to reduce flicker.
  * Building settings saves now show clearer error messages and use the shared API.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->