### PR TITLE
fix(command-center): address #45 review follow-ups (I1, I2, I3, I4, I6)

### DIFF
--- a/backend/app/api/websocket.py
+++ b/backend/app/api/websocket.py
@@ -204,11 +204,20 @@ class ConnectionManager:
     # Overview-level WebSocket support (Command Center — cross-session)
     # ------------------------------------------------------------------
 
-    async def connect_overview(self, websocket: WebSocket) -> None:
-        """Accept a WebSocket connection and register it for the overview feed."""
-        await websocket.accept()
+    async def connect_overview(self, websocket: WebSocket, *, max_connections: int) -> bool:
+        """Accept a WebSocket connection and register it for the overview feed.
+
+        Returns False (without accepting) when adding the connection would
+        exceed ``max_connections``. The cap check and the append both run under
+        the lock to close the TOCTOU window where a burst of concurrent
+        handshakes each pass the limit before any registers.
+        """
         async with self._lock:
+            if len(self.overview_connections) >= max_connections:
+                return False
+            await websocket.accept()
             self.overview_connections.append(websocket)
+            return True
 
     async def disconnect_overview(self, websocket: WebSocket) -> None:
         """Remove a WebSocket connection from the overview feed."""

--- a/backend/app/core/event_processor.py
+++ b/backend/app/core/event_processor.py
@@ -366,12 +366,19 @@ class EventProcessor:
 
         await self._persist_event(event, resolved_floor_id, resolved_room_id)
 
+        # Replay from DB *before* acquiring the lock: the restore is async I/O
+        # that can take hundreds of ms for a long session, and holding the lock
+        # across it stalls the debounced overview broadcast and /ws/overview
+        # connects. Only the dict insertion below needs the lock.
+        restored: StateMachine | None = None
+        if event.session_id not in self.sessions:
+            restored = await self._build_restored_state_machine(event.session_id)
+
         async with self._sessions_lock:
             if event.session_id not in self.sessions:
-                await self._restore_session(event.session_id)
-
-            if event.session_id not in self.sessions:
-                self.sessions[event.session_id] = StateMachine()
+                self.sessions[event.session_id] = (
+                    restored if restored is not None else StateMachine()
+                )
 
             # Capture the StateMachine reference while still holding the lock so a
             # concurrent clear_all_sessions()/remove_session() can't drop the key
@@ -576,6 +583,18 @@ class EventProcessor:
         except Exception as e:
             logger.exception(f"Error broadcasting overview state: {e}")
 
+    async def shutdown(self) -> None:
+        """Cancel a pending debounced overview broadcast on app shutdown.
+
+        Without this the flush task is left pending at loop close and asyncio
+        logs "Task was destroyed but it is pending!".
+        """
+        task = self._overview_flush_task
+        if task is not None and not task.done():
+            task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await task
+
     async def build_overview_snapshot(self) -> OverviewState:
         """Build a cross-session overview under ``_sessions_lock``.
 
@@ -622,11 +641,14 @@ class EventProcessor:
             db.add(event_rec)
             await db.commit()
 
-    async def _restore_session(self, session_id: str) -> None:
+    async def _build_restored_state_machine(self, session_id: str) -> StateMachine | None:
         """Reconstruct a StateMachine from persisted DB events.
 
         Replays all events for the session through a fresh StateMachine,
-        rebuilding agent state, conversation history, and task lists.
+        rebuilding agent state, conversation history, and task lists. Performs
+        only async DB I/O against a locally-built machine, so it is safe to call
+        without holding ``_sessions_lock``; the caller inserts the result under
+        the lock. Returns ``None`` when the session has no persisted events.
 
         Args:
             session_id: The session to restore.
@@ -640,7 +662,7 @@ class EventProcessor:
             events = result.scalars().all()
 
             if not events:
-                return
+                return None
 
             logger.info(f"Restoring session {session_id} from {len(events)} events in DB")
 
@@ -750,7 +772,19 @@ class EventProcessor:
             sm.todos = await load_tasks(session_id)
             logger.debug(f"Restored {len(sm.todos)} tasks for session {session_id}")
 
-            self.sessions[session_id] = sm
+            return sm
+
+    async def _restore_session(self, session_id: str) -> None:
+        """Reconstruct and insert a session's StateMachine, if it has events.
+
+        Builds the machine (async DB I/O) without holding the lock, then inserts
+        it under ``_sessions_lock`` so the registry stays consistent with
+        readers such as ``build_overview``.
+        """
+        sm = await self._build_restored_state_machine(session_id)
+        if sm is not None:
+            async with self._sessions_lock:
+                self.sessions[session_id] = sm
 
     async def _persist_event(
         self,

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -182,6 +182,8 @@ async def lifespan(_app: FastAPI) -> AsyncGenerator[None]:
 
     yield
 
+    # Cancel any pending debounced overview broadcast so shutdown is clean.
+    await event_processor.shutdown()
     await git_service.stop()
     await get_engine().dispose()
 
@@ -268,12 +270,13 @@ async def websocket_overview(websocket: WebSocket) -> None:
 
     # Cap concurrent overview watchers: each connection amplifies the per-event
     # overview rebuild cost, so refuse beyond the limit instead of letting it
-    # grow unbounded.
-    if len(manager.overview_connections) >= _MAX_OVERVIEW_CONNECTIONS:
+    # grow unbounded. The check is enforced atomically with the registration
+    # inside connect_overview (under the manager lock) so a burst of concurrent
+    # handshakes can't each pass the limit before any registers.
+    accepted = await manager.connect_overview(websocket, max_connections=_MAX_OVERVIEW_CONNECTIONS)
+    if not accepted:
         await websocket.close(code=4013, reason="Too many overview connections")
         return
-
-    await manager.connect_overview(websocket)
     try:
         # Send the current overview snapshot on connect. Built under the same
         # ``_sessions_lock`` used by the per-event broadcast so it reads a

--- a/backend/tests/test_websocket_room.py
+++ b/backend/tests/test_websocket_room.py
@@ -51,7 +51,7 @@ class TestOverviewConnections:
         mgr = ConnectionManager()
         ws = AsyncMock()
         ws.client_state = MagicMock()
-        await mgr.connect_overview(ws)
+        await mgr.connect_overview(ws, max_connections=16)
         assert ws in mgr.overview_connections
 
     @pytest.mark.asyncio
@@ -59,7 +59,7 @@ class TestOverviewConnections:
         mgr = ConnectionManager()
         ws = AsyncMock()
         ws.client_state = MagicMock()
-        await mgr.connect_overview(ws)
+        await mgr.connect_overview(ws, max_connections=16)
         await mgr.disconnect_overview(ws)
         assert ws not in mgr.overview_connections
 
@@ -70,7 +70,7 @@ class TestOverviewConnections:
         from starlette.websockets import WebSocketState
 
         ws.client_state = WebSocketState.CONNECTED
-        await mgr.connect_overview(ws)
+        await mgr.connect_overview(ws, max_connections=16)
         await mgr.broadcast_overview({"type": "test"})
         ws.send_json.assert_called_once_with({"type": "test"})
 
@@ -79,6 +79,23 @@ class TestOverviewConnections:
         mgr = ConnectionManager()
         # Should not raise
         await mgr.broadcast_overview({"type": "test"})
+
+    @pytest.mark.asyncio
+    async def test_connect_overview_enforces_cap_atomically(self) -> None:
+        """connect_overview rejects (returns False) once the cap is reached, so a
+        burst of concurrent handshakes can't each register past the limit."""
+        mgr = ConnectionManager()
+        # Fill up to the cap.
+        for _ in range(2):
+            ws = AsyncMock()
+            ws.client_state = MagicMock()
+            assert await mgr.connect_overview(ws, max_connections=2) is True
+        # The next one must be refused without being accepted or registered.
+        extra = AsyncMock()
+        extra.client_state = MagicMock()
+        assert await mgr.connect_overview(extra, max_connections=2) is False
+        assert extra not in mgr.overview_connections
+        extra.accept.assert_not_called()
 
 
 class TestOverviewRouteOrder:
@@ -116,7 +133,7 @@ class TestBroadcastOverviewState:
 
         ws = AsyncMock()
         ws.client_state = WebSocketState.CONNECTED
-        await ws_module.manager.connect_overview(ws)
+        await ws_module.manager.connect_overview(ws, max_connections=16)
         try:
             sm = StateMachine()
             sm.boss_state = BossState.WAITING_PERMISSION

--- a/frontend/src/stores/overviewStore.ts
+++ b/frontend/src/stores/overviewStore.ts
@@ -25,26 +25,26 @@ interface OverviewState {
 // ============================================================================
 
 /**
- * Shallow-equal two entry lists on only the fields consumers read. Lets the
- * store skip a state update (and the resulting re-render of every consumer)
- * when a WS frame carries no meaningful change.
+ * Shallow-equal two entry lists so the store can skip a state update (and the
+ * resulting re-render of every consumer) when a WS frame carries no meaningful
+ * change.
+ *
+ * Compares *every* field present on either entry rather than a hardcoded list,
+ * so a newly-added OverviewEntry field can't silently fail to trigger a
+ * re-render. All current fields are primitives, so a value comparison is
+ * enough (a future nested field would over-render — safe, just less optimal).
+ * Using the union of keys lets an omitted optional field compare equal to an
+ * explicit undefined.
  */
-function entriesEqual(a: OverviewEntry[], b: OverviewEntry[]): boolean {
+export function entriesEqual(a: OverviewEntry[], b: OverviewEntry[]): boolean {
   if (a === b) return true;
   if (a.length !== b.length) return false;
   for (let i = 0; i < a.length; i++) {
     const x = a[i];
     const y = b[i];
-    if (
-      x.sessionId !== y.sessionId ||
-      x.bucket !== y.bucket ||
-      x.state !== y.state ||
-      x.currentTask !== y.currentTask ||
-      x.todoDone !== y.todoDone ||
-      x.todoTotal !== y.todoTotal ||
-      x.subagentCount !== y.subagentCount
-    ) {
-      return false;
+    const keys = new Set<string>([...Object.keys(x), ...Object.keys(y)]);
+    for (const key of keys) {
+      if (x[key] !== y[key]) return false;
     }
   }
   return true;

--- a/frontend/src/systems/astar.ts
+++ b/frontend/src/systems/astar.ts
@@ -10,6 +10,8 @@ import {
   GridPosition,
   PathGrid,
   TILE_SIZE,
+  GRID_WIDTH,
+  GRID_HEIGHT,
   getNavigationGrid,
 } from "./navigationGrid";
 
@@ -234,8 +236,11 @@ function findNearestWalkable(
   pos: GridPosition,
   ignoreAgentId?: string,
 ): GridPosition | null {
-  // Spiral search outward
-  const maxRadius = 5;
+  // Spiral search outward. Scale to the grid dimensions so a blocked endpoint
+  // always snaps to the nearest walkable tile if one exists anywhere on the
+  // grid — a fixed small radius could miss it and leave the caller to snap
+  // straight through furniture. Both grids share GRID_WIDTH/GRID_HEIGHT.
+  const maxRadius = Math.max(GRID_WIDTH, GRID_HEIGHT);
 
   for (let radius = 1; radius <= maxRadius; radius++) {
     for (let dx = -radius; dx <= radius; dx++) {
@@ -252,6 +257,9 @@ function findNearestWalkable(
     }
   }
 
+  console.warn(
+    `[astar] findNearestWalkable: no walkable tile within ${maxRadius} of (${pos.gx}, ${pos.gy})`,
+  );
   return null;
 }
 

--- a/frontend/tests/overviewStore.test.ts
+++ b/frontend/tests/overviewStore.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import { entriesEqual } from "@/stores/overviewStore";
+import type { OverviewEntry } from "@/types";
+
+const baseEntry: OverviewEntry = {
+  sessionId: "s1",
+  bucket: "working",
+  state: "working",
+  currentTask: "task A",
+  todoDone: 1,
+  todoTotal: 3,
+  subagentCount: 0,
+};
+
+describe("entriesEqual", () => {
+  it("treats identical entries as equal (so the store can skip the update)", () => {
+    expect(entriesEqual([baseEntry], [{ ...baseEntry }])).toBe(true);
+  });
+
+  it("returns false when ANY field differs", () => {
+    // Guards against a new OverviewEntry field silently failing to trigger a
+    // re-render: entriesEqual compares every present field, so varying each
+    // known field must be detected.
+    const variants: Record<string, unknown> = {
+      sessionId: "s2",
+      bucket: "done",
+      state: "idle",
+      currentTask: "task B",
+      todoDone: 2,
+      todoTotal: 4,
+      subagentCount: 1,
+    };
+    // Iterate the entry's own keys so a newly-added field included above is
+    // checked automatically.
+    for (const key of Object.keys(baseEntry)) {
+      const changed = { ...baseEntry, [key]: variants[key] } as OverviewEntry;
+      expect(entriesEqual([baseEntry], [changed])).toBe(false);
+    }
+  });
+
+  it("treats an omitted optional field the same as an explicit undefined", () => {
+    const withoutTask = { ...baseEntry } as OverviewEntry;
+    delete (withoutTask as Record<string, unknown>).currentTask;
+    const withUndefined = {
+      ...baseEntry,
+      currentTask: undefined,
+    } as OverviewEntry;
+    expect(entriesEqual([withoutTask], [withUndefined])).toBe(true);
+  });
+
+  it("returns false for different-length lists", () => {
+    expect(entriesEqual([baseEntry], [])).toBe(false);
+  });
+});


### PR DESCRIPTION
Implements the deferred non-blocking follow-ups from the #45 re-review. All are surgical; make checkall + 309 backend / 27 frontend tests green.

## Backend

- **I1 — restore_session lock scope** (`event_processor.py`): the async DB replay now runs *outside* `_sessions_lock` (build the StateMachine lock-free, insert it under the lock). Previously a long replay held the lock for hundreds of ms on a first event, stalling the debounced overview broadcast and `/ws/overview` connects. Splits `_restore_session` into a lock-free `_build_restored_state_machine` builder + a thin insert-under-lock wrapper.
- **I2 — overview cap TOCTOU** (`websocket.py` + `main.py`): the 16-connection cap is now enforced atomically *inside* `connect_overview` under the manager lock (check + accept + append together), returning `False` when over. Previously the check ran outside the lock, so a burst of concurrent handshakes could each pass before any registered. Added a test (`test_connect_overview_enforces_cap_atomically`).
- **I3 — flush task on shutdown** (`event_processor.py` + `main.py`): new `event_processor.shutdown()` cancels the pending `_overview_flush_task` (which was already designed to be cancellable), wired into the app lifespan before `git_service.stop()`. Removes the `Task was destroyed but it is pending!` warning.

## Frontend

- **I4 — entriesEqual field coverage** (`overviewStore.ts`): replaces the hardcoded 7-field list with a comparison of *every* field present on either entry (union of keys, so an omitted optional compares equal to `undefined`). A newly-added `OverviewEntry` field can no longer silently fail to trigger a re-render. Added `tests/overviewStore.test.ts`.
- **I6 — findNearestWalkable radius** (`astar.ts`): scales the search radius to `max(GRID_WIDTH, GRID_HEIGHT)` instead of a hardcoded 5, so a blocked endpoint always finds the nearest walkable tile anywhere on the grid rather than giving up and letting the caller snap straight through furniture; warns when none is found.

I5 (defensive `resetExit()` in the exit-driver cleanup) was already shipped with #45.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enforced a limit on concurrent overview connections to prevent overload.
  * Improved application shutdown to eliminate pending cleanup errors.
  * Added diagnostic warnings when pathfinding cannot locate walkable tiles.

* **Tests**
  * Enhanced test coverage for overview state comparison and connection limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->