### PR TITLE
fix(command-center): stop ended peers looping out of the elevator

### DIFF
--- a/frontend/src/systems/exitAnimation.test.ts
+++ b/frontend/src/systems/exitAnimation.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  useExitStore,
+  resetExit,
+  exitProgress,
+  EXIT_DURATION,
+} from "./exitAnimation";
+
+describe("exitAnimation registerEnded", () => {
+  beforeEach(() => resetExit());
+
+  it("does not re-walk a peer that already finished its exit", () => {
+    const id = "s1";
+    // Session ends → starts walking out at t=0.
+    useExitStore.getState().registerEnded([id], 0);
+    const t0 = useExitStore.getState().startTimes.get(id);
+    expect(t0).toBe(0);
+
+    // Exit completes.
+    expect(exitProgress(id, EXIT_DURATION, useExitStore.getState().startTimes)).toBe(1);
+
+    // Peer still lingers in the Ended zone, so the effect calls registerEnded
+    // again with a fresh clock. The start time must NOT reset — otherwise the
+    // agent loops walking out of the elevator forever.
+    useExitStore.getState().registerEnded([id], 99999);
+    expect(useExitStore.getState().startTimes.get(id)).toBe(0);
+  });
+
+  it("drops a session once it leaves the ended set (bounded map)", () => {
+    useExitStore.getState().registerEnded(["s1"], 0);
+    useExitStore.getState().registerEnded([], 100);
+    expect(useExitStore.getState().startTimes.has("s1")).toBe(false);
+  });
+});

--- a/frontend/src/systems/exitAnimation.ts
+++ b/frontend/src/systems/exitAnimation.ts
@@ -20,8 +20,6 @@ interface ExitState {
   setNow: (now: number) => void;
   /** Register the current ended sessions; new ones start their exit now. */
   registerEnded: (ids: string[], t: number) => void;
-  /** Drop sessions whose exit animation has finished by `now`. */
-  pruneCompleted: (now: number) => void;
 }
 
 export const useExitStore = create<ExitState>()((set) => ({
@@ -51,18 +49,6 @@ export const useExitStore = create<ExitState>()((set) => ({
     // Re-arm the self-gating driver loop when a new exit begins.
     if (added) ensureExitRaf();
   },
-  pruneCompleted: (now) =>
-    set((s) => {
-      const next = new Map(s.startTimes);
-      let changed = false;
-      for (const [id, st] of s.startTimes)
-        if ((now - st) / EXIT_DURATION >= 1) {
-          next.delete(id);
-          changed = true;
-        }
-      // Preserve Map identity when nothing changed (avoids re-render churn).
-      return changed ? { startTimes: next } : {};
-    }),
 }));
 
 /** Clear all exit state (call on Command Center unmount). */
@@ -117,9 +103,11 @@ function tick(): void {
   if (active) {
     rafId = requestAnimationFrame(tick);
   } else {
-    // Nothing animating: drop finished exits and stop the loop. It re-arms
-    // from registerEnded when the next session leaves.
-    s.pruneCompleted(now);
+    // Nothing animating: stop the loop. Finished exits stay in startTimes as
+    // the "already walked out" memory so an ended peer that lingers in the
+    // Ended zone (RECENT_ENDED_MS) isn't re-registered and made to walk out on
+    // a loop. registerEnded drops them when the session leaves the zone, so the
+    // map stays bounded. The loop re-arms from registerEnded on the next exit.
     rafId = null;
   }
 }


### PR DESCRIPTION
## Problem

In the Command Center, an ended session's agent walks out of the elevator on an **infinite loop** — it keeps re-spawning at the queue spot and walking out forever.

## Root cause

`exitAnimation.ts`'s `startTimes` map doubles as the "this session already walked out" memory. But `pruneCompleted` *deleted* each entry the moment its walk-out animation finished. The ended peer lingers in the Ended zone for `RECENT_ENDED_MS` (30 min), and the `registerEnded` effect re-runs on every 30s `now`-tick and every overview update. With the entry pruned, it saw `!startTimes.has(id)` and **re-registered the session with a fresh start time → replayed the walk-out**, over and over.

## Fix

- Drop `pruneCompleted`. Finished exits stay in `startTimes` as the "already exited" memory, so they aren't re-registered.
- `registerEnded` already removes sessions that leave the Ended set (the `!idSet.has(id)` loop), so the map stays bounded — no leak.
- The self-gating RAF driver still stops correctly (all progress ≥ 1 → `active = false`); `selectDoorOpen` ignores completed entries.

## Test

Adds `exitAnimation.test.ts`:
- a peer that finished its exit is **not** re-walked when `registerEnded` fires again while it lingers,
- a session is dropped from the map once it leaves the ended set (bounded).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test suite for exit animation state management behavior.

* **Refactor**
  * Optimized exit animation tracking by removing active pruning logic while maintaining bounded state retention.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->