### PR TITLE
fix(hooks): avoid SSL context for http POSTs to prevent OpenSSL crash on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to Claude Office Visualizer are documented here.
 
 - **Schedule-editor cron helpers (frontend)**: new `src/utils/cron.ts` with pure functions that round-trip between a friendly schedule editor and a 5-field cron expression — `timesToCron` (fixed daily times → cron), `intervalToCron` (every-N-minutes within an hour window → cron), and `cronToEditor` (parse cron back into editor state, falling back to a raw-mode escape hatch), plus `DEFAULT_BUSINESS_HOURS` (8–23) and `enterTimesHours`. Zero dependencies, 12 vitest cases. Mined from PR #51, whose companion `pathfinding.ts` was rejected because the existing `systems/astar.ts` is strictly superior (binary heap, 8-directional)
 
+### Fixed
+
+- **Hook crash on Windows with a conflicting system OpenSSL (`OPENSSL_Uplink: no OPENSSL_Applink`)**: `send_event` posts only to the local backend over plain HTTP, but Python 3.14's `urllib.request.urlopen` builds an SSL-capable opener (an `HTTPSHandler` whose context is created eagerly). On machines where a foreign OpenSSL config/cert is in play (e.g. `SSL_CERT_FILE`/`SSL_CERT_DIR` set by another install, or a `libcrypto` in `System32`), creating that context aborts the whole process at the C level — so no event was ever sent and the office stayed empty. The hook now builds an `OpenerDirector` with only `HTTPHandler` for `http://` URLs (no SSL context, no crash) and keeps the standard SSL-capable opener for `https://` backends, so remote deployments are unaffected
+
 ## [0.21.0] - 2026-06-17
 
 ### Changed

--- a/hooks/src/claude_office_hooks/main.py
+++ b/hooks/src/claude_office_hooks/main.py
@@ -39,6 +39,24 @@ try:
     _config = load_config()
     DEBUG = _config.get("CLAUDE_OFFICE_DEBUG", "0") == "1"
 
+    def _open_request(req: "urllib.request.Request") -> Any:
+        """Open *req* without ever creating an SSL context for http URLs.
+
+        On some Windows setups the bundled OpenSSL aborts the whole process
+        (``OPENSSL_Uplink: no OPENSSL_Applink``) the moment an SSL context is
+        created, because reading the OpenSSL config/cert file via stdio needs
+        an applink shim the standalone python launcher does not export. The
+        default backend is local plain http, so for http URLs we build an
+        opener with only ``HTTPHandler`` — no ``HTTPSHandler``, no ssl import
+        side effects, no crash. https URLs keep the standard opener so remote
+        deployments still work.
+        """
+        if API_URL.lower().startswith("https"):
+            return urllib.request.urlopen(req, timeout=TIMEOUT)
+        opener = urllib.request.OpenerDirector()
+        opener.add_handler(urllib.request.HTTPHandler())
+        return opener.open(req, timeout=TIMEOUT)
+
     def send_event(payload: dict[str, Any]) -> None:
         """POST *payload* as JSON to the backend API.
 
@@ -51,7 +69,7 @@ try:
             if api_key:
                 headers["X-API-Key"] = api_key
             req = urllib.request.Request(API_URL, data=json_data, headers=headers)
-            with urllib.request.urlopen(req, timeout=TIMEOUT) as response:
+            with _open_request(req) as response:
                 if response.status >= 300:
                     log_error(
                         RuntimeError(f"backend returned HTTP {response.status}"),


### PR DESCRIPTION
## Problem

On Windows with a conflicting system OpenSSL, the hook aborts at the C level before sending any event, so the office never populates:

```
OPENSSL_Uplink(00007FFB...,08): no OPENSSL_Applink
```

`send_event` only ever POSTs to the local backend over plain HTTP, but Python 3.14's `urllib.request.urlopen` builds an SSL-capable opener whose `HTTPSHandler` context is created eagerly. When a foreign OpenSSL config/cert is in play — e.g. `SSL_CERT_FILE`/`SSL_CERT_DIR` set by another tool (a PHP install in my case), or a stray `libcrypto-3-x64.dll` in `System32` — creating that context calls into OpenSSL's stdio path, which needs the `OPENSSL_Applink` shim the standalone Python launcher doesn't export, and the process aborts. Because it's a C-level abort, the hook's try/except can't catch it and nothing is logged.

### Reproduction

On an affected machine, any of these abort the process:

```
python -c "import ssl; ssl._create_unverified_context()"
python -c "import urllib.request as u; u.urlopen('http://localhost:8000/health')"
```

while a plain-HTTP path with no SSL context works fine:

```
python -c "import http.client; c=http.client.HTTPConnection('localhost',8000); c.request('GET','/health'); print(c.getresponse().status)"  # 200
```

## Fix

For `http://` URLs, build an `OpenerDirector` with only `HTTPHandler` — no `HTTPSHandler`, so no SSL context is ever created. `https://` backends keep the standard `urlopen` opener, so remote deployments are unaffected. The default backend URL is `http://localhost:8000/api/v1/events`, so the common path no longer touches SSL at all.

## Testing

- Verified the real installed `claude-office-hook` shim posts `session_start` / `user_prompt_submit` / `pre_tool_use` / `post_tool_use` with exit 0 and the events land (`GET /api/v1/sessions` shows the session, `eventCount` increments).
- Confirmed end-to-end render: sessions appear in the sidebar, status flips to CONNECTED, and the boss desk marquee shows the live task.
- `ruff check` and `ruff format --check` pass on the changed file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a Windows crash that could occur when a conflicting system OpenSSL configuration was present.
  * Improved request handling so HTTP connections avoid SSL-related setup, while HTTPS connections continue to use secure handling as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->